### PR TITLE
Clarify keystroke to stop adding entity fields

### DIFF
--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -211,7 +211,7 @@ EOT
 
         while (true) {
             $output->writeln('');
-            $name = $dialog->ask($output, $dialog->getQuestion('New field name (type return to stop adding fields)', null));
+            $name = $dialog->ask($output, $dialog->getQuestion('New field name (press <return> to stop adding fields)', null));
             if (!$name) {
                 break;
             }


### PR DESCRIPTION
Just a minor gotcha, I typed the literal string "return" based on the input hint, which of course generated a "return" property for my entity. Asking the user to press a key instead of type a key seems more clear to me.
