### PR TITLE
Incorrect path to messages.fr.xliff

### DIFF
--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -55,7 +55,7 @@ class BundleGenerator extends Generator
             $this->filesystem->mkdir($dir.'/Resources/doc');
             $this->filesystem->touch($dir.'/Resources/doc/index.rst');
             $this->filesystem->mkdir($dir.'/Resources/translations');
-            $this->filesystem->copy($this->skeletonDir.'/structure/messages.fr.xliff', $dir.'/Resources/translations/messages.fr.xliff');
+            $this->filesystem->copy($this->skeletonDir.'/messages.fr.xliff', $dir.'/Resources/translations/messages.fr.xliff');
             $this->filesystem->mkdir($dir.'/Resources/public/css');
             $this->filesystem->mkdir($dir.'/Resources/public/images');
             $this->filesystem->mkdir($dir.'/Resources/public/js');


### PR DESCRIPTION
Incorrect path to messages.fr.xliff file causing ErrorException in console.

 [ErrorException]  
  Warning: copy(/Applications/MAMP/Websites/Symfony/vendor/bundles/Sensio/Bundle/GeneratorBundle/Command/../Resources/skeleton/bundle/structure/messages.fr.xliff): failed to open stream: No such file or directory in /Applications/MAMP/Websites/Symfony/vendor/symfony/src/Symfony/Component/HttpKernel/Util/Filesystem.php line 44  
