### PR TITLE
Strip /Bundle/ from suggested bundle name

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -154,7 +154,7 @@ EOT
         $input->setOption('namespace', $namespace);
 
         // bundle name
-        $bundle = $input->getOption('bundle-name') ?: strtr($namespace, array('\\' => ''));
+        $bundle = $input->getOption('bundle-name') ?: strtr($namespace, array('\\Bundle\\' => '', '\\' => ''));
         $output->writeln(array(
             '',
             'In your code, a bundle is often referenced by its name. It can be the',


### PR DESCRIPTION
I don't think it makes sense that you suggest people call their bundle `Acme/Bundle/FooBundle` and then it doesn't strip the Bundle in the middle. I sure don't want to end up with hundreds of bundles called FooBundleBarBundle :)
