### PR TITLE
[2.2] Generated templates now extend ::base.html.twig

### DIFF
--- a/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -1,12 +1,16 @@
-<h1>{{ entity }} edit</h1>
+{{ "{% extends '::base.html.twig' %}" }}
 
-<form action="{{ "{{ path('"~ route_name_prefix ~"_update', { 'id': entity.id }) }}" }}" method="post" {{ "{{ form_enctype(edit_form) }}" }}>
-    <input type="hidden" name="_method" value="PUT" />
-    {{ "{{ form_widget(edit_form) }}" }}
-    <p>
-        <button type="submit">Edit</button>
-    </p>
-</form>
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} edit</h1>
 
-{% set hide_edit, hide_delete = true, false %}
-{% include 'views/others/record_actions.html.twig.twig' %}
+    <form action="{{ "{{ path('" ~ route_name_prefix ~ "_update', { 'id': entity.id }) }}" }}" method="post" {{ "{{ form_enctype(edit_form) }}" }}>
+        <input type="hidden" name="_method" value="PUT" />
+        {{ "{{ form_widget(edit_form) }}" }}
+        <p>
+            <button type="submit">Edit</button>
+        </p>
+    </form>
+
+    {% set hide_edit, hide_delete = true, false %}
+    {% include 'views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -1,56 +1,60 @@
-<h1>{{ entity }} list</h1>
+{{ "{% extends '::base.html.twig' %}" }}
 
-<table class="records_list">
-    <thead>
-        <tr>
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} list</h1>
+
+    <table class="records_list">
+        <thead>
+            <tr>
+            {%- for field, metadata in fields %}
+
+                <th>{{ field|capitalize }}</th>
+
+            {%- endfor %}
+
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{ '{% for entity in entities %}' }}
+            <tr>
+
         {%- for field, metadata in fields %}
+            {%- if loop.first and ('show' in actions) %}
 
-            <th>{{ field|capitalize }}</th>
+                <td><a href="{{ "{{ path('" ~ route_name_prefix ~ "_show', { 'id': entity.id }) }}" }}">{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</a></td>
 
+            {%- elseif metadata.type in ['date', 'datetime'] %}
+
+                <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
+
+            {%- else %}
+
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
+
+            {%- endif %}
+
+            {%- if loop.last %}
+
+                <td>
+                    {%- include "views/others/actions.html.twig.twig" %}
+                </td>
+
+            {%- endif %}
         {%- endfor %}
 
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-    {{ '{% for entity in entities %}' }}
-        <tr>
+            </tr>
+        {{ '{% endfor %}' }}
+        </tbody>
+    </table>
 
-    {%- for field, metadata in fields %}
-        {%- if loop.first and ('show' in actions) %}
-
-            <td><a href="{{ "{{ path('"~ route_name_prefix ~"_show', { 'id': entity.id }) }}" }}">{{ '{{ entity.'~ field|replace({'_': ''}) ~' }}' }}</a></td>
-
-        {%- elseif metadata.type in ['date', 'datetime'] %}
-
-            <td>{{ '{% if entity.'~ field|replace({'_': ''}) ~' %}{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
-
-        {%- else %}
-
-            <td>{{ '{{ entity.'~ field|replace({'_': ''}) ~' }}' }}</td>
-
-        {%- endif %}
-
-        {%- if loop.last %}
-
-            <td>
-                {%- include "views/others/actions.html.twig.twig" %}
-            </td>
-
-        {%- endif %}
-    {%- endfor %}
-
-        </tr>
-    {{ '{% endfor %}' }}
-    </tbody>
-</table>
-
-{% if 'new' in actions %}
-<ul>
-    <li>
-        <a href="{{ "{{ path('"~ route_name_prefix ~"_new') }}" }}">
-            Create a new entry
-        </a>
-    </li>
-</ul>
-{% endif %}
+    {% if 'new' in actions %}
+    <ul>
+        <li>
+            <a href="{{ "{{ path('" ~ route_name_prefix ~ "_new') }}" }}">
+                Create a new entry
+            </a>
+        </li>
+    </ul>
+    {% endif %}
+{{ "{% endblock %}" }}

--- a/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/Resources/skeleton/crud/views/new.html.twig.twig
@@ -1,11 +1,15 @@
-<h1>{{ entity }} creation</h1>
+{{ "{% extends '::base.html.twig' %}" }}
 
-<form action="{{ "{{ path('"~ route_name_prefix ~"_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
-    {{ "{{ form_widget(form) }}" }}
-    <p>
-        <button type="submit">Create</button>
-    </p>
-</form>
+{{ "{% block body -%}" }}
+    <h1>{{ entity }} creation</h1>
 
-{% set hide_edit, hide_delete = true, true %}
-{% include 'views/others/record_actions.html.twig.twig' %}
+    <form action="{{ "{{ path('" ~ route_name_prefix ~ "_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
+        {{ "{{ form_widget(form) }}" }}
+        <p>
+            <button type="submit">Create</button>
+        </p>
+    </form>
+
+    {% set hide_edit, hide_delete = true, true %}
+    {% include 'views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}

--- a/Resources/skeleton/crud/views/others/actions.html.twig.twig
+++ b/Resources/skeleton/crud/views/others/actions.html.twig.twig
@@ -4,7 +4,7 @@
                 {%- for action in record_actions %}
 
                     <li>
-                        <a href="{{ "{{ path('"~ route_name_prefix ~"_"~ action ~"', { 'id': entity.id }) }}" }}">{{ action }}</a>
+                        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_" ~ action ~ "', { 'id': entity.id }) }}" }}">{{ action }}</a>
                     </li>
 
                 {%- endfor %}

--- a/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
+++ b/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
@@ -1,19 +1,19 @@
 <ul class="record_actions">
     <li>
-        <a href="{{ "{{ path('"~ route_name_prefix ~"') }}" }}">
+        <a href="{{ "{{ path('" ~ route_name_prefix ~ "') }}" }}">
             Back to the list
         </a>
     </li>
 {% if ('edit' in actions) and (not hide_edit) %}
     <li>
-        <a href="{{ "{{ path('"~ route_name_prefix ~"_edit', { 'id': entity.id }) }}" }}">
+        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_edit', { 'id': entity.id }) }}" }}">
             Edit
         </a>
     </li>
 {% endif %}
 {% if ('delete' in actions) and (not hide_delete) %}
     <li>
-        <form action="{{ "{{ path('"~ route_name_prefix ~"_delete', { 'id': entity.id }) }}" }}" method="post">
+        <form action="{{ "{{ path('" ~ route_name_prefix ~ "_delete', { 'id': entity.id }) }}" }}" method="post">
             <input type="hidden" name="_method" value="DELETE" />
             {{ '{{ form_widget(delete_form) }}' }}
             <button type="submit">Delete</button>

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -1,28 +1,32 @@
-<h1>{{ entity }}</h1>
+{{ "{% extends '::base.html.twig' %}" }}
 
-<table class="record_properties">
-    <tbody>
-    {%- for field, metadata in fields %}
+{{ "{% block body -%}" }}
+    <h1>{{ entity }}</h1>
 
-        <tr>
-            <th>{{ field|capitalize }}</th>
+    <table class="record_properties">
+        <tbody>
+        {%- for field, metadata in fields %}
 
-        {%- if metadata.type in ['date', 'datetime'] %}
+            <tr>
+                <th>{{ field|capitalize }}</th>
 
-            <td>{{ '{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}' }}</td>
+            {%- if metadata.type in ['date', 'datetime'] %}
 
-        {%- else %}
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}' }}</td>
 
-            <td>{{ '{{ entity.'~ field|replace({'_': ''}) ~' }}' }}</td>
+            {%- else %}
 
-        {%- endif %}
+                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
 
-        </tr>
+            {%- endif %}
 
-    {%- endfor %}
+            </tr>
 
-    </tbody>
-</table>
+        {%- endfor %}
 
-{% set hide_edit, hide_delete = false, false %}
-{% include 'views/others/record_actions.html.twig.twig' %}
+        </tbody>
+    </table>
+
+    {% set hide_edit, hide_delete = false, false %}
+    {% include 'views/others/record_actions.html.twig.twig' %}
+{{ "{% endblock %}" }}


### PR DESCRIPTION
Generated templates for CRUD should extend '::base.html.twig' as a best practise.
Besides, it allows to have the web debug toolbar on the generated pages too.
