### PR TITLE
[Generator] fixed broken CRUD generator because the "route_name_prefix" v

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -171,15 +171,16 @@ class DoctrineCrudGenerator extends Generator
         }
 
         $this->renderFile($this->skeletonDir, 'controller.php', $target, array(
-            'actions'          => $this->actions,
-            'route_prefix'     => $this->routePrefix,
-            'dir'              => $this->skeletonDir,
-            'bundle'           => $this->bundle->getName(),
-            'entity'           => $this->entity,
-            'entity_class'     => $entityClass,
-            'namespace'        => $this->bundle->getNamespace(),
-            'entity_namespace' => $entityNamespace,
-            'format'           => $this->format,
+            'actions'           => $this->actions,
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
+            'dir'               => $this->skeletonDir,
+            'bundle'            => $this->bundle->getName(),
+            'entity'            => $this->entity,
+            'entity_class'      => $entityClass,
+            'namespace'         => $this->bundle->getNamespace(),
+            'entity_namespace'  => $entityNamespace,
+            'format'            => $this->format,
         ));
     }
 
@@ -197,13 +198,14 @@ class DoctrineCrudGenerator extends Generator
         $target = $dir .'/'. str_replace('\\', '/', $entityNamespace).'/'. $entityClass .'ControllerTest.php';
 
         $this->renderFile($this->skeletonDir, 'tests/test.php', $target, array(
-            'route_prefix'     => $this->routePrefix, 
-            'entity'           => $this->entity,
-            'entity_class'     => $entityClass,
-            'namespace'        => $this->bundle->getNamespace(),
-            'entity_namespace' => $entityNamespace,
-            'actions'          => $this->actions,
-            'dir'              => $this->skeletonDir,
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
+            'entity'            => $this->entity,
+            'entity_class'      => $entityClass,
+            'namespace'         => $this->bundle->getNamespace(),
+            'entity_namespace'  => $entityNamespace,
+            'actions'           => $this->actions,
+            'dir'               => $this->skeletonDir,
         ));
     }
 
@@ -215,12 +217,13 @@ class DoctrineCrudGenerator extends Generator
     private function generateIndexView($dir)
     {
         $this->renderFile($this->skeletonDir, 'views/index.html.twig', $dir.'/index.html.twig', array(
-            'dir'            => $this->skeletonDir,
-            'entity'         => $this->entity,
-            'fields'         => $this->metadata->fieldMappings,
-            'actions'        => $this->actions,
-            'record_actions' => $this->getRecordActions(),
-            'route_prefix'   => $this->routePrefix,
+            'dir'               => $this->skeletonDir,
+            'entity'            => $this->entity,
+            'fields'            => $this->metadata->fieldMappings,
+            'actions'           => $this->actions,
+            'record_actions'    => $this->getRecordActions(),
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
         ));
     }
 
@@ -232,11 +235,12 @@ class DoctrineCrudGenerator extends Generator
     private function generateShowView($dir)
     {
         $this->renderFile($this->skeletonDir, 'views/show.html.twig', $dir.'/show.html.twig', array(
-            'dir'          => $this->skeletonDir,
-            'entity'       => $this->entity,
-            'fields'       => $this->metadata->fieldMappings,
-            'actions'      => $this->actions,
-            'route_prefix' => $this->routePrefix,
+            'dir'               => $this->skeletonDir,
+            'entity'            => $this->entity,
+            'fields'            => $this->metadata->fieldMappings,
+            'actions'           => $this->actions,
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
         ));
     }
 
@@ -248,10 +252,11 @@ class DoctrineCrudGenerator extends Generator
     private function generateNewView($dir)
     {
         $this->renderFile($this->skeletonDir, 'views/new.html.twig', $dir.'/new.html.twig', array(
-            'dir'          => $this->skeletonDir,
-            'route_prefix' => $this->routePrefix,
-            'entity'       => $this->entity,
-            'actions'      => $this->actions,
+            'dir'               => $this->skeletonDir,
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
+            'entity'            => $this->entity,
+            'actions'           => $this->actions,
         ));
     }
 
@@ -263,10 +268,11 @@ class DoctrineCrudGenerator extends Generator
     private function generateEditView($dir)
     {
         $this->renderFile($this->skeletonDir, 'views/edit.html.twig', $dir.'/edit.html.twig', array(
-            'dir'          => $this->skeletonDir,
-            'route_prefix' => $this->routePrefix,
-            'entity'       => $this->entity,
-            'actions'      => $this->actions,
+            'dir'               => $this->skeletonDir,
+            'route_prefix'      => $this->routePrefix,
+            'route_name_prefix' => $this->routeNamePrefix,
+            'entity'            => $this->entity,
+            'actions'           => $this->actions,
         ));
     }
 


### PR DESCRIPTION
[Generator] fixed broken CRUD generator because the "route_name_prefix" variable was missing in templates.
