### PR TITLE
[Resources] fixed DefaultControllerTest.php skeleton that used the old in

### DIFF
--- a/Resources/skeleton/bundle/DefaultControllerTest.php
+++ b/Resources/skeleton/bundle/DefaultControllerTest.php
@@ -8,7 +8,7 @@ class DefaultControllerTest extends WebTestCase
 {
     public function testIndex()
     {
-        $client = $this->createClient();
+        $client = static::createClient();
 
         $crawler = $client->request('GET', '/hello/Fabien');
 


### PR DESCRIPTION
[Resources] fixed DefaultControllerTest.php skeleton that used the old instance call to createClient() method instead of a static call.
