### PR TITLE
Adds the entity type class only if write actions are needed in Crud generator

### DIFF
--- a/Resources/skeleton/crud/controller.php
+++ b/Resources/skeleton/crud/controller.php
@@ -10,7 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 {%- endif %}
 
 use {{ namespace }}\Entity\{{ entity }};
-{% if 'new' in actions and 'edit' in actions %}
+{% if 'new' in actions or 'edit' in actions %}
 use {{ namespace }}\Form\{{ entity }}Type;
 {% endif %}
 


### PR DESCRIPTION
Generating CRUD controllers, use of classes for entity type are added to Controllers if write actions are not needed. Those entity type classes doesn't exists in that case.
