### PR TITLE
Fix created bundle addition to the Kernel class.

### DIFF
--- a/Manipulator/KernelManipulator.php
+++ b/Manipulator/KernelManipulator.php
@@ -89,7 +89,9 @@ class KernelManipulator extends Manipulator
                 $this->next();
 
                 $lines = array_merge(
-                    array_slice($src, 0, $this->line - 1),
+                    array_slice($src, 0, $this->line - 2),
+                    // Appends a separator comma to the current last position of the array
+                    array(rtrim(rtrim($src[$this->line - 2]), ',') . ",\n"),
                     array(sprintf("            new %s(),\n", $bundle)),
                     array_slice($src, $this->line - 1)
                 );


### PR DESCRIPTION
This appends a separator comma to the last position of the bundles array, preventing syntax errors on the Kernel class file. If the comma already exists, it is replaced.
