### PR TITLE
changed: don't show a date/datetime if the field is null 

### DIFF
--- a/Resources/skeleton/crud/views/index.html.twig
+++ b/Resources/skeleton/crud/views/index.html.twig
@@ -23,7 +23,7 @@
 
         {%- elseif metadata.type in ['date', 'datetime'] %}
 
-            <td>{{ '{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}' }}</td>
+            <td>{{ '{% if entity.'~ field|replace({'_': ''}) ~' %}{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}{% endif%}' }}</td>
 
         {%- else %}
 


### PR DESCRIPTION
The date filter will show the current date with a null value, wich it's not the expected behavior
