### PR TITLE
[Generator] Add a controller-dir option to the CRUD generator

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -41,6 +41,7 @@ class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
         $this
             ->setDefinition(array(
                 new InputOption('entity', '', InputOption::VALUE_REQUIRED, 'The entity class name to initialize (shortcut notation)'),
+                new InputOption('controller-dir', '', InputOption::VALUE_REQUIRED, 'The controller directory (Controller)', 'Controller'),
                 new InputOption('route-prefix', '', InputOption::VALUE_REQUIRED, 'The route prefix'),
                 new InputOption('with-write', '', InputOption::VALUE_NONE, 'Whether or not to generate create, new and delete actions'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation'),
@@ -90,9 +91,10 @@ EOT
         $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
         $metadata    = $this->getEntityMetadata($entityClass);
         $bundle      = $this->getContainer()->get('kernel')->getBundle($bundle);
+        $dir         = $input->getOption('controller-dir');
 
         $generator = $this->getGenerator();
-        $generator->generate($bundle, $entity, $metadata[0], $format, $prefix, $withWrite);
+        $generator->generate($bundle, $entity, $metadata[0], $format, $prefix, $withWrite, $dir);
 
         $output->writeln('Generating the CRUD code: <info>OK</info>');
 
@@ -138,6 +140,21 @@ EOT
         // Entity exists?
         $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
         $metadata = $this->getEntityMetadata($entityClass);
+
+        // Controller dir
+        $output->writeln(array(
+            '',
+            'Define the directory where the controller will be generated (if you change this value, ',
+            'it must be under the Controller folder).',
+            '',
+            'For example, if you define Controller/Backend, the controller will be generated under',
+            '<comment>Sensio/AcmeBlogBundle/Controller/Backend/PostController.php </comment>',
+            'with the namespace <comment>Sensio/AcmeBlogBundle/Controller/Backend</comment>',
+            'and the views will be in <comment>Sensio/AcmeBlogBundle/Resources/views/backend/Post</comment>',
+            '',
+        ));
+        $dir = $dialog->ask($output, $dialog->getQuestion('The controller directory', $input->getOption('controller-dir')), $input->getOption('controller-dir'));
+        $input->setOption('controller-dir', $dir);
 
         // write?
         $withWrite = $input->getOption('with-write') ?: false;

--- a/Resources/skeleton/crud/controller.php
+++ b/Resources/skeleton/crud/controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace {{ namespace }}\Controller{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+namespace {{ namespace }}\{{ controller_namespace }}{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 {% if 'annotation' == format -%}

--- a/Resources/skeleton/crud/tests/test.php
+++ b/Resources/skeleton/crud/tests/test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace {{ namespace }}\Tests\Controller{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
+namespace {{ namespace }}\Tests\{{ controller_namespace }}{{ entity_namespace ? '\\' ~ entity_namespace : '' }};
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 

--- a/Resources/skeleton/crud/views/edit.html.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig
@@ -1,11 +1,6 @@
 <h1>{{ entity }} edit</h1>
 
-<form action="{{ "{{ path('"~ route_name_prefix ~"_update', { 'id': entity.id }) }}" }}" method="post" {{ "{{ form_enctype(edit_form) }}" }}>
-    {{ "{{ form_widget(edit_form) }}" }}
-    <p>
-        <button type="submit">Edit</button>
-    </p>
-</form>
+{{ "{% include '"~ bundle ~":"~ form_dir ~":form.html.twig' with { 'form': edit_form, 'entity': entity } %}" }}
 
 {% set hide_edit, hide_delete = true, false %}
 {% include 'views/others/record_actions.html.twig' %}

--- a/Resources/skeleton/crud/views/form.html.twig
+++ b/Resources/skeleton/crud/views/form.html.twig
@@ -1,0 +1,6 @@
+<form action="{{ "{{ entity.id ? path('"~ route_name_prefix ~"_update', { 'id': entity.id }) : path('"~ route_name_prefix ~"_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
+    {{ "{{ form_widget(form) }}" }}
+    <p>
+        <button type="submit">{{ "{{ entity.id ? 'Edit' : 'Create' }}" }}</button>
+    </p>
+</form>

--- a/Resources/skeleton/crud/views/new.html.twig
+++ b/Resources/skeleton/crud/views/new.html.twig
@@ -1,11 +1,6 @@
 <h1>{{ entity }} creation</h1>
 
-<form action="{{ "{{ path('"~ route_name_prefix ~"_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
-    {{ "{{ form_widget(form) }}" }}
-    <p>
-        <button type="submit">Create</button>
-    </p>
-</form>
+{{ "{% include '"~ bundle ~":"~ form_dir ~":form.html.twig' with { 'form': form, 'entity': entity } %}" }}
 
 {% set hide_edit, hide_delete = true, true %}
 {% include 'views/others/record_actions.html.twig' %}

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -51,6 +51,18 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         foreach ($strings as $string) {
             $this->assertContains($string, $content);
         }
+
+        $this->getGenerator()->generate($this->getBundle(), 'User', $this->getMetadata(), 'yml', '/user', false, 'Controller/Backend');
+
+        $files = array(
+            'Controller/Backend/UserController.php',
+            'Tests/Controller/Backend/UserControllerTest.php',
+            'Resources/views/Backend/User/index.html.twig',
+            'Resources/views/Backend/User/show.html.twig',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
+        }
     }
 
     public function testGenerateXml()
@@ -96,6 +108,18 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         foreach ($strings as $string) {
             $this->assertNotContains($string, $content);
         }
+
+        $this->getGenerator()->generate($this->getBundle(), 'User', $this->getMetadata(), 'xml', '/user', false, 'Controller/Backend');
+
+        $files = array(
+            'Controller/Backend/UserController.php',
+            'Tests/Controller/Backend/UserControllerTest.php',
+            'Resources/views/Backend/User/index.html.twig',
+            'Resources/views/Backend/User/show.html.twig',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
+        }
     }
 
     public function testGenerateAnnotationWrite()
@@ -109,6 +133,7 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
             'Resources/views/Post/show.html.twig',
             'Resources/views/Post/new.html.twig',
             'Resources/views/Post/edit.html.twig',
+            'Resources/views/Post/form.html.twig',
         );
         foreach ($files as $file) {
             $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
@@ -134,6 +159,21 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         foreach ($strings as $string) {
             $this->assertContains($string, $content);
         }
+
+        $this->getGenerator()->generate($this->getBundle(), 'User', $this->getMetadata(), 'annotation', '/user', true, 'Controller/Backend');
+
+        $files = array(
+            'Controller/Backend/UserController.php',
+            'Tests/Controller/Backend/UserControllerTest.php',
+            'Resources/views/Backend/User/index.html.twig',
+            'Resources/views/Backend/User/show.html.twig',
+            'Resources/views/Backend/User/new.html.twig',
+            'Resources/views/Backend/User/edit.html.twig',
+            'Resources/views/Backend/User/form.html.twig',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
+        }
     }
 
     public function testGenerateAnnotation()
@@ -148,16 +188,6 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         );
         foreach ($files as $file) {
             $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
-        }
-
-        $files = array(
-            'Resources/config/routing/post.yml',
-            'Resources/config/routing/post.xml',
-            'Resources/views/Post/new.html.twig',
-            'Resources/views/Post/edit.html.twig',
-        );
-        foreach ($files as $file) {
-            $this->assertFalse(file_exists($this->tmpDir.'/'.$file), sprintf('%s has not been generated', $file));
         }
 
         $content = file_get_contents($this->tmpDir.'/Controller/PostController.php');
@@ -178,6 +208,18 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         );
         foreach ($strings as $string) {
             $this->assertNotContains($string, $content);
+        }
+
+        $this->getGenerator()->generate($this->getBundle(), 'User', $this->getMetadata(), 'annotation', '/user', false, 'Controller/Backend');
+
+        $files = array(
+            'Controller/Backend/UserController.php',
+            'Tests/Controller/Backend/UserControllerTest.php',
+            'Resources/views/Backend/User/index.html.twig',
+            'Resources/views/Backend/User/show.html.twig',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
         }
     }
 


### PR DESCRIPTION
Generates controller, views and tests under a specific directory
(Controller/Backend for instance)
Refactor views, add a form view that is used by the new and edit ones.
