### PR TITLE
Bugfix: Fixed faulty use statement caused by change in symfony/symfony

### DIFF
--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\DependencyInjection\Container;
 
 /**


### PR DESCRIPTION
Bugfix: Fixed faulty use statement: Symfony\Component\HttpKernel\Util\Filesystem -> Symfony\Component\Filesystem\Filesystem, caused by change https://github.com/symfony/symfony/commit/818a3321c01c504c5aed05caf9a8b3984071a82d in symfony/symfony
