### PR TITLE
Use the Filesystem Component namespace

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 


### PR DESCRIPTION
Use the good namespace of the new component Filesystem to generate entity ... 

[ErrorException]  
  Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineEntityGenerator::__construct() must be an instance of Symfony\Component\HttpKernel\Util\Filesystem, instance of Symfony\Component\Filesystem\Filesystem given, called in www/vendor/bundles/Sensio/Bundle/GeneratorBundle/Command/GenerateDoctrineEntityCommand.php on line 293 and defined in www/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineEntityGenerator.php line 33  

BR,
Maxime
