### PR TITLE
[Skeleton] Check if datetime fields are defined as the same way of index.html.twig skeleton

### DIFF
--- a/Resources/skeleton/crud/views/show.html.twig
+++ b/Resources/skeleton/crud/views/show.html.twig
@@ -9,7 +9,7 @@
 
         {%- if metadata.type in ['date', 'datetime'] %}
 
-            <td>{{ '{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}' }}</td>
+            <td>{{ '{% if entity.'~ field|replace({'_': ''}) ~' %}{{ entity.'~ field|replace({'_': ''}) ~'|date(\'Y-m-d H:i:s\') }}{% endif%}' }}</td>
 
         {%- else %}
 


### PR DESCRIPTION
show.html.twig doesn't check if datetime is defined before to use `date` filter.

Added the same check than already implemented in index.html.twig