### PR TITLE
Tests seems broken

### DIFF
--- a/Tests/Generator/GeneratorTest.php
+++ b/Tests/Generator/GeneratorTest.php
@@ -11,7 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
 
-use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem;
 
 abstract class GeneratorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Hi,
running test on branch 2.0 i got this errors.

There were 7 errors:

1) Sensio\Bundle\GeneratorBundle\Tests\Generator\BundleGeneratorTest::testGenerateYaml
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/BundleGeneratorTest.php on line 21 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/BundleGenerator.php line 27

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/BundleGenerator.php:27
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/BundleGeneratorTest.php:21

2) Sensio\Bundle\GeneratorBundle\Tests\Generator\BundleGeneratorTest::testGenerateAnnotation
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/BundleGeneratorTest.php on line 51 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/BundleGenerator.php line 27

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/BundleGenerator.php:27
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/BundleGeneratorTest.php:51

3) Sensio\Bundle\GeneratorBundle\Tests\Generator\DoctrineCrudGeneratorTest::testGenerateYamlFull
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php on line 186 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php line 41

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php:41
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:186
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:21

4) Sensio\Bundle\GeneratorBundle\Tests\Generator\DoctrineCrudGeneratorTest::testGenerateXml
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php on line 186 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php line 41

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php:41
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:186
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:58

5) Sensio\Bundle\GeneratorBundle\Tests\Generator\DoctrineCrudGeneratorTest::testGenerateAnnotationWrite
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php on line 186 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php line 41

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php:41
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:186
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:103

6) Sensio\Bundle\GeneratorBundle\Tests\Generator\DoctrineCrudGeneratorTest::testGenerateAnnotation
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php on line 186 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php line 41

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineCrudGenerator.php:41
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:186
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineCrudGeneratorTest.php:141

7) Sensio\Bundle\GeneratorBundle\Tests\Generator\DoctrineFormGeneratorTest::testGenerate
ErrorException: Catchable Fatal Error: Argument 1 passed to Sensio\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator::__construct() must be an instance of Symfony\Component\Filesystem\Filesystem, instance of Symfony\Component\HttpKernel\Util\Filesystem given, called in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineFormGeneratorTest.php on line 21 and defined in /var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineFormGenerator.php line 31

/var/www/ABMundi/vendor/symfony/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php:65
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Generator/DoctrineFormGenerator.php:31
/var/www/ABMundi/vendor/bundles/Sensio/Bundle/GeneratorBundle/Tests/Generator/DoctrineFormGeneratorTest.php:21

It seems there's an error in namespace.
I tryed to fix it ... could u check it?
