### PR TITLE
app/console doctrine:generate:crud does not if @AcmeMyBundle/Resources/config/routing.yml is not empty

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -204,7 +204,11 @@ EOT
         $output->write('Importing the CRUD routes: ');
         $this->getContainer()->get('filesystem')->mkdir($bundle->getPath().'/Resources/config/');
         $routing = new RoutingManipulator($bundle->getPath().'/Resources/config/routing.yml');
-        $ret = $auto ? $routing->addResource($bundle->getName(), $format, '/'.$prefix, 'routing/'.strtolower(str_replace('\\', '_', $entity))) : false;
+        try {
+            $ret = $auto ? $routing->addResource($bundle->getName(), $format, '/'.$prefix, 'routing/'.strtolower(str_replace('\\', '_', $entity))) : false;
+        } catch (\RuntimeException $exc) {
+            $ret = false;
+        }
         if (!$ret) {
             $help = sprintf("        <comment>resource: \"@%s/Resources/config/routing/%s.%s\"</comment>\n", $bundle->getName(), strtolower(str_replace('\\', '_', $entity)), $format);
             $help .= sprintf("        <comment>prefix:   /%s</comment>\n", $prefix);


### PR DESCRIPTION
If I run this command 2 times for the same bundle, for 2 different entities for example, it throw a RuntimeException braking the wizard. I catched it and ignored so it completed the wizard.
