### PR TITLE
introduced automatically adding a twig extends tag and blockname

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -44,6 +44,8 @@ class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
                 new InputOption('route-prefix', '', InputOption::VALUE_REQUIRED, 'The route prefix'),
                 new InputOption('with-write', '', InputOption::VALUE_NONE, 'Whether or not to generate create, new and delete actions'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation'),
+                new InputOption('basetemplate', '', InputOption::VALUE_OPTIONAL, 'The basetemplate to extend'),
+                new InputOption('blockname', '', InputOption::VALUE_OPTIONAL, 'The blockname in which the page bodies should be placed'),
             ))
             ->setDescription('Generates a CRUD based on a Doctrine entity')
             ->setHelp(<<<EOT
@@ -56,6 +58,10 @@ The default command only generates the list and show actions.
 Using the --with-write option allows to generate the new, edit and delete actions.
 
 <info>php app/console doctrine:generate:crud --entity=AcmeBlogBundle:Post --route-prefix=post_admin --with-write</info>
+
+Additionally, you can automatically generate the extends- and block tags if you already have those for your project. For this, you need to pass the basetemplate and blockname options.
+
+<info>php app/console doctrine:generate:crud --entity=AcmeBlogBundle:Post --basetemplate=::layout.html.twig --blockname=content</info>
 EOT
             )
             ->setName('doctrine:generate:crud')
@@ -92,7 +98,7 @@ EOT
         $bundle      = $this->getContainer()->get('kernel')->getBundle($bundle);
 
         $generator = $this->getGenerator();
-        $generator->generate($bundle, $entity, $metadata[0], $format, $prefix, $withWrite);
+        $generator->generate($bundle, $entity, $metadata[0], $format, $prefix, $withWrite$input->getOption('basetemplate'), $input->getOption('blockname'));
 
         $output->writeln('Generating the CRUD code: <info>OK</info>');
 
@@ -159,6 +165,27 @@ EOT
         ));
         $format = $dialog->askAndValidate($output, $dialog->getQuestion('Configuration format (yml, xml, php, or annotation)', $format), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateFormat'), false, $format);
         $input->setOption('format', $format);
+
+        // base template
+        $basetemplate = $input->getOption('basetemplate');
+        $output->writeln(array(
+            '',
+            'If you want to use a basetemplate to extend from, enter the name',
+            '',
+        ));
+        $basetemplate = $dialog->ask($output, $dialog->getQuestion('Enter the name of the base template', $basetemplate), $basetemplate);
+        $input->setOption('basetemplate', $basetemplate);
+
+        // block name
+        $blockname = $input->getOption('blockname');
+        $output->writeln(array(
+            '',
+            'When using a base template, in which block should the page content be placed',
+            '',
+        ));
+        $blockname = $dialog->ask($output, $dialog->getQuestion('Name of the block for the page content', $blockname), $blockname);
+        $input->setOption('blockname', $blockname);
+
 
         // route prefix
         $prefix = $this->getRoutePrefix($input, $entity);

--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -31,6 +31,8 @@ class DoctrineCrudGenerator extends Generator
     private $metadata;
     private $format;
     private $actions;
+    private $basetemplate;
+    private $blockname;
 
     /**
      * Constructor.
@@ -56,7 +58,7 @@ class DoctrineCrudGenerator extends Generator
      *
      * @throws \RuntimeException
      */
-    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata, $format, $routePrefix, $needWriteActions)
+    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata, $format, $routePrefix, $needWriteActions, $basetemplate = null, $blockname = null)
     {
         $this->routePrefix = $routePrefix;
         $this->routeNamePrefix = str_replace('/', '_', $routePrefix);
@@ -74,6 +76,8 @@ class DoctrineCrudGenerator extends Generator
         $this->bundle   = $bundle;
         $this->metadata = $metadata;
         $this->setFormat($format);
+        $this->basetemplate = $basetemplate;
+        $this->blockname = $blockname;
 
         $this->generateControllerClass();
 
@@ -224,6 +228,8 @@ class DoctrineCrudGenerator extends Generator
             'record_actions'    => $this->getRecordActions(),
             'route_prefix'      => $this->routePrefix,
             'route_name_prefix' => $this->routeNamePrefix,
+            'basetemplate'      => $this->basetemplate,
+            'blockname'         => $this->blockname,
         ));
     }
 
@@ -241,6 +247,8 @@ class DoctrineCrudGenerator extends Generator
             'actions'           => $this->actions,
             'route_prefix'      => $this->routePrefix,
             'route_name_prefix' => $this->routeNamePrefix,
+            'basetemplate'      => $this->basetemplate,
+            'blockname'         => $this->blockname,
         ));
     }
 
@@ -257,6 +265,9 @@ class DoctrineCrudGenerator extends Generator
             'route_name_prefix' => $this->routeNamePrefix,
             'entity'            => $this->entity,
             'actions'           => $this->actions,
+            'basetemplate'      => $this->basetemplate,
+            'blockname'         => $this->blockname,
+
         ));
     }
 
@@ -273,6 +284,8 @@ class DoctrineCrudGenerator extends Generator
             'route_name_prefix' => $this->routeNamePrefix,
             'entity'            => $this->entity,
             'actions'           => $this->actions,
+            'basetemplate'      => $this->basetemplate,
+            'blockname'         => $this->blockname,
         ));
     }
 

--- a/Resources/skeleton/crud/views/edit.html.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig
@@ -1,3 +1,4 @@
+{% include 'views/others/template_header.html.twig' %}
 <h1>{{ entity }} edit</h1>
 
 <form action="{{ "{{ path('"~ route_name_prefix ~"_update', { 'id': entity.id }) }}" }}" method="post" {{ "{{ form_enctype(edit_form) }}" }}>
@@ -9,3 +10,4 @@
 
 {% set hide_edit, hide_delete = true, false %}
 {% include 'views/others/record_actions.html.twig' %}
+{% include 'views/others/template_footer.html.twig' %}

--- a/Resources/skeleton/crud/views/index.html.twig
+++ b/Resources/skeleton/crud/views/index.html.twig
@@ -1,3 +1,4 @@
+{% include 'views/others/template_header.html.twig' %}
 <h1>{{ entity }} list</h1>
 
 <table class="records_list">
@@ -54,3 +55,4 @@
     </li>
 </ul>
 {% endif %}
+{% include 'views/others/template_footer.html.twig' %}

--- a/Resources/skeleton/crud/views/new.html.twig
+++ b/Resources/skeleton/crud/views/new.html.twig
@@ -1,3 +1,4 @@
+{% include 'views/others/template_header.html.twig' %}
 <h1>{{ entity }} creation</h1>
 
 <form action="{{ "{{ path('"~ route_name_prefix ~"_create') }}" }}" method="post" {{ "{{ form_enctype(form) }}" }}>
@@ -9,3 +10,4 @@
 
 {% set hide_edit, hide_delete = true, true %}
 {% include 'views/others/record_actions.html.twig' %}
+{% include 'views/others/template_footer.html.twig' %}

--- a/Resources/skeleton/crud/views/others/template_footer.html.twig
+++ b/Resources/skeleton/crud/views/others/template_footer.html.twig
@@ -1,0 +1,5 @@
+{% if blockname %}
+    {% raw %}
+    {% endblock %}
+    {% endraw %}
+{% endif %}

--- a/Resources/skeleton/crud/views/others/template_header.html.twig
+++ b/Resources/skeleton/crud/views/others/template_header.html.twig
@@ -1,0 +1,6 @@
+{% if basetemplate %}
+{% raw %}{% extends '{% endraw %}{{ basetemplate }}{% raw %}' %}{% endraw %}
+{% endif %}
+{% if blockname %}
+{% raw %}{% block {% endraw %}{{ blockname }}{% raw %} %}{% endraw %}
+{% endif %}

--- a/Resources/skeleton/crud/views/show.html.twig
+++ b/Resources/skeleton/crud/views/show.html.twig
@@ -1,3 +1,4 @@
+{% include 'views/others/template_header.html.twig' %}
 <h1>{{ entity }}</h1>
 
 <table class="record_properties">
@@ -26,3 +27,4 @@
 
 {% set hide_edit, hide_delete = false, false %}
 {% include 'views/others/record_actions.html.twig' %}
+{% include 'views/others/template_footer.html.twig' %}


### PR DESCRIPTION
One of the things I've noticed when generated basic CRUD pages for applications I've already been working on for a while is the first thing I do: add extends and block tags to all generated templates. 

This pull request removes the need to do that every time you've used the CRUD generation, by enabling an optional template name and block name. By specifying the template name and block name, the templates that are generated will extend the specified base template and all page output will be placed between a block tag.