### PR TITLE
Make sure the bundle can work without DoctrineBundle

### DIFF
--- a/Command/GenerateDoctrineCommand.php
+++ b/Command/GenerateDoctrineCommand.php
@@ -12,10 +12,15 @@
 namespace Sensio\Bundle\GeneratorBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Mapping\MetadataFactory;
-use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
-abstract class GenerateDoctrineCommand extends DoctrineCommand
+abstract class GenerateDoctrineCommand extends ContainerAwareCommand
 {
+    public function isEnabled()
+    {
+        return class_exists('Doctrine\\Bundle\\DoctrineBundle\\DoctrineBundle');
+    }
+
     protected function parseShortcutNotation($shortcut)
     {
         $entity = str_replace('/', '\\', $shortcut);


### PR DESCRIPTION
Didn't test if it was still working _with_ doctrine, but it disables it correctly instead of blowing up my console now in this project that doesn't have doctrine bundle.
