### PR TITLE
Replaced deprecated method "getEntityManager" by "getManager"

### DIFF
--- a/Resources/skeleton/crud/actions/create.php
+++ b/Resources/skeleton/crud/actions/create.php
@@ -16,7 +16,7 @@
         $form->bindRequest($request);
 
         if ($form->isValid()) {
-            $em = $this->getDoctrine()->getEntityManager();
+            $em = $this->getDoctrine()->getManager();
             $em->persist($entity);
             $em->flush();
 

--- a/Resources/skeleton/crud/actions/delete.php
+++ b/Resources/skeleton/crud/actions/delete.php
@@ -15,7 +15,7 @@
         $form->bindRequest($request);
 
         if ($form->isValid()) {
-            $em = $this->getDoctrine()->getEntityManager();
+            $em = $this->getDoctrine()->getManager();
             $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
 
             if (!$entity) {

--- a/Resources/skeleton/crud/actions/edit.php
+++ b/Resources/skeleton/crud/actions/edit.php
@@ -9,7 +9,7 @@
      */
     public function editAction($id)
     {
-        $em = $this->getDoctrine()->getEntityManager();
+        $em = $this->getDoctrine()->getManager();
 
         $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
 

--- a/Resources/skeleton/crud/actions/index.php
+++ b/Resources/skeleton/crud/actions/index.php
@@ -9,7 +9,7 @@
      */
     public function indexAction()
     {
-        $em = $this->getDoctrine()->getEntityManager();
+        $em = $this->getDoctrine()->getManager();
 
         $entities = $em->getRepository('{{ bundle }}:{{ entity }}')->findAll();
 

--- a/Resources/skeleton/crud/actions/show.php
+++ b/Resources/skeleton/crud/actions/show.php
@@ -9,7 +9,7 @@
      */
     public function showAction($id)
     {
-        $em = $this->getDoctrine()->getEntityManager();
+        $em = $this->getDoctrine()->getManager();
 
         $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
 

--- a/Resources/skeleton/crud/actions/update.php
+++ b/Resources/skeleton/crud/actions/update.php
@@ -10,7 +10,7 @@
      */
     public function updateAction($id)
     {
-        $em = $this->getDoctrine()->getEntityManager();
+        $em = $this->getDoctrine()->getManager();
 
         $entity = $em->getRepository('{{ bundle }}:{{ entity }}')->find($id);
 


### PR DESCRIPTION
Using "getManager" as it is explained in the [book](http://symfony.com/doc/master/book/doctrine.html#persisting-objects-to-the-database) for the master branch.
