### PR TITLE
Fixed the composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,8 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.*"
-    },
-    "recommend": {
-        "symfony/doctrine-bundle": "2.*"
+        "symfony/framework-bundle": "2.0.*",
+        "symfony/doctrine-bundle": "2.0.*"
     },
     "autoload": {
         "psr-0": { "Sensio\\Bundle\\GeneratorBundle": "" }


### PR DESCRIPTION
The 2.0 branch of the bundle requires DoctrineBundle 2.0 (as the commands extend the base class) and work only with FrameworkBundle 2.0
