### PR TITLE
Fixed generate:bundle command help escaping

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -148,7 +148,7 @@ EOT
             'See http://symfony.com/doc/current/cookbook/bundles/best_practices.html#index-1 for more',
             'details on bundle naming conventions.',
             '',
-            'Use <comment>/</comment> instead of <comment>\\</comment> for the namespace delimiter to avoid any problem.',
+            'Use <comment>/</comment> instead of <comment>\\ </comment> for the namespace delimiter to avoid any problem.',
             '',
         ));
 


### PR DESCRIPTION
Console component uses `\<` as the syntax to escape `<` character
since https://github.com/symfony/symfony/pull/4832
