### PR TITLE
Generate bundle routing names with undescores

### DIFF
--- a/Manipulator/RoutingManipulator.php
+++ b/Manipulator/RoutingManipulator.php
@@ -11,6 +11,8 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Manipulator;
 
+use Symfony\Component\DependencyInjection\Container;
+
 /**
  * Changes the PHP code of a YAML routing file.
  *
@@ -56,7 +58,7 @@ class RoutingManipulator extends Manipulator
             mkdir($dir, 0777, true);
         }
 
-        $code = sprintf("%s:\n", $bundle.('/' !== $prefix ? '_'.str_replace('/', '_', substr($prefix, 1)) : ''));
+        $code = sprintf("%s:\n", Container::underscore(substr($bundle, 0, -6)).('/' !== $prefix ? '_'.str_replace('/', '_', substr($prefix, 1)) : ''));
         if ('annotation' == $format) {
             $code .= sprintf("    resource: \"@%s/Controller/\"\n    type:     annotation\n", $bundle);
         } else {

--- a/Resources/skeleton/bundle/routing.php
+++ b/Resources/skeleton/bundle/routing.php
@@ -4,7 +4,7 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
 
 $collection = new RouteCollection();
-$collection->add('{{ bundle }}_homepage', new Route('/hello/{name}', array(
+$collection->add('{{ extension_alias }}_homepage', new Route('/hello/{name}', array(
     '_controller' => '{{ bundle }}:Default:index',
 )));
 

--- a/Resources/skeleton/bundle/routing.xml
+++ b/Resources/skeleton/bundle/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="{{ bundle }}_homepage" pattern="/hello/{name}">
+    <route id="{{ extension_alias }}_homepage" pattern="/hello/{name}">
         <default key="_controller">{{ bundle }}:Default:index</default>
     </route>
 </routes>

--- a/Resources/skeleton/bundle/routing.yml
+++ b/Resources/skeleton/bundle/routing.yml
@@ -1,3 +1,3 @@
-{{ bundle }}_homepage:
+{{ extension_alias }}_homepage:
     pattern:  /hello/{name}
     defaults: { _controller: {{ bundle }}:Default:index }


### PR DESCRIPTION
According to cookbook documentation:
http://symfony.com/doc/master/cookbook/bundles/best_practices.html#routing
and conventions of some existing bundles I believe generated routing names should be underscored instead of CamelCased.

If this pull request goes through, than there will have to be an update to docs as well:
http://symfony.com/doc/master/book/page_creation.html#step-1-create-the-route

Thanks and kind regards.
