### PR TITLE
Fix test generator by using the right form name

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -205,6 +205,7 @@ class DoctrineCrudGenerator extends Generator
             'namespace'         => $this->bundle->getNamespace(),
             'entity_namespace'  => $entityNamespace,
             'actions'           => $this->actions,
+            'form_type_name'    => strtolower(str_replace('\\', '_', $this->bundle->getNamespace()).($parts ? '_' : '').implode('_', $parts).'_'.$entityClass.'Type'),
             'dir'               => $this->skeletonDir,
         ));
     }

--- a/Resources/skeleton/crud/tests/others/full_scenario.php
+++ b/Resources/skeleton/crud/tests/others/full_scenario.php
@@ -11,7 +11,7 @@
 
         // Fill in the form and submit it
         $form = $crawler->selectButton('Create')->form(array(
-            '{{ entity_class|lower }}[field_name]'  => 'Test',
+            '{{ form_type_name|lower }}[field_name]'  => 'Test',
             // ... other fields to fill
         ));
 
@@ -25,7 +25,7 @@
         $crawler = $client->click($crawler->selectLink('Edit')->link());
 
         $form = $crawler->selectButton('Edit')->form(array(
-            '{{ entity_class|lower }}[field_name]'  => 'Foo',
+            '{{ form_type_name|lower }}[field_name]'  => 'Foo',
             // ... other fields to fill
         ));
 


### PR DESCRIPTION
Currently, the automatically generated controller test uses the entity class as the form name which is incorrect. Fixed it.
