### PR TITLE
Full extensibility of commands

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -185,7 +185,7 @@ EOT
     /**
      * Tries to generate forms if they don't exist yet and if we need write operations on entities.
      */
-    private function generateForm($bundle, $entity, $metadata)
+    protected function generateForm($bundle, $entity, $metadata)
     {
         try {
             $this->getFormGenerator()->generate($bundle, $entity, $metadata[0]);
@@ -194,7 +194,7 @@ EOT
         }
     }
 
-    private function updateRouting($dialog, InputInterface $input, OutputInterface $output, $bundle, $format, $entity, $prefix)
+    protected function updateRouting($dialog, InputInterface $input, OutputInterface $output, $bundle, $format, $entity, $prefix)
     {
         $auto = true;
         if ($input->isInteractive()) {


### PR DESCRIPTION
This patch allows users to extend the commands fully.

We wanted to generate routing as yaml and services as xml but when doing a quick extension of the command we've discovered we didn't had access to those functions. 

A better way for our case would be ask what type should be used for each of the 'sub-components' but that would still not solve the problem of inheritance.

Thanks!
