### PR TITLE
Match method requirements to templates

### DIFF
--- a/Resources/skeleton/crud/config/routing.php.twig
+++ b/Resources/skeleton/crud/config/routing.php.twig
@@ -37,7 +37,7 @@ $collection->add('{{ route_name_prefix }}_edit', new Route('/{id}/edit', array(
 $collection->add('{{ route_name_prefix }}_update', new Route(
     '/{id}/update',
     array('_controller' => '{{ bundle }}:{{ entity }}:update'),
-    array('_method' => 'post')
+    array('_method' => 'post|put')
 ));
 {% endif %}
 
@@ -45,7 +45,7 @@ $collection->add('{{ route_name_prefix }}_update', new Route(
 $collection->add('{{ route_name_prefix }}_delete', new Route(
     '/{id}/delete',
     array('_controller' => '{{ bundle }}:{{ entity }}:delete'),
-    array('_method' => 'post')
+    array('_method' => 'post|delete')
 ));
 {% endif %}
 

--- a/Resources/skeleton/crud/config/routing.xml.twig
+++ b/Resources/skeleton/crud/config/routing.xml.twig
@@ -30,14 +30,14 @@
 
     <route id="{{ route_name_prefix }}_update" pattern="/{id}/update">
         <default key="_controller">{{ bundle }}:{{ entity }}:update</default>
-        <requirement key="_method">post</requirement>
+        <requirement key="_method">post|put</requirement>
     </route>
 {% endif %}
 
 {% if 'delete' in actions %}
     <route id="{{ route_name_prefix }}_delete" pattern="/{id}/delete">
         <default key="_controller">{{ bundle }}:{{ entity }}:delete</default>
-        <requirement key="_method">post</requirement>
+        <requirement key="_method">post|delete</requirement>
     </route>
 {% endif %}
 

--- a/Resources/skeleton/crud/config/routing.yml.twig
+++ b/Resources/skeleton/crud/config/routing.yml.twig
@@ -29,12 +29,12 @@
 {{ route_name_prefix }}_update:
     pattern:  /{id}/update
     defaults: { _controller: "{{ bundle }}:{{ entity }}:update" }
-    requirements: { _method: post }
+    requirements: { _method: post|put }
 {% endif %}
 
 {% if 'delete' in actions %}
 {{ route_name_prefix }}_delete:
     pattern:  /{id}/delete
     defaults: { _controller: "{{ bundle }}:{{ entity }}:delete" }
-    requirements: { _method: post }
+    requirements: { _method: post|delete }
 {% endif %}


### PR DESCRIPTION
This PR updates generated routes to allows PUT and DELETE requests for /update and /delete respectively. These are the methods that are used in the templates.
