### PR TITLE
Fixed: GenerateDoctrineFormCommand: createGenerator() method not implemented cause PHP Fatal error

### DIFF
--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -77,4 +77,9 @@ EOT
             $generator->getClassPath()
         ));
     }
+
+    protected function createGenerator()
+    {
+        return new DoctrineFormGenerator($this->getContainer()->get('filesystem'));
+    }
 }


### PR DESCRIPTION
createGenerator() is implemented. now don`t give error with "composer install". (here i tried to run test but failed)
