### PR TITLE
improved bundle name validation

### DIFF
--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -51,6 +51,10 @@ class Validators
 
     public static function validateBundleName($bundle)
     {
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $bundle)) {
+            throw new \InvalidArgumentException('The bundle name contains invalid characters.');
+        }
+        
         if (!preg_match('/Bundle$/', $bundle)) {
             throw new \InvalidArgumentException('The bundle name must end with Bundle.');
         }


### PR DESCRIPTION
Bundle name should have at least same level of validation as namespace has.
