### PR TITLE
Replaced deprecated methods "getEntityNamespace" and "getEntityManager"

### DIFF
--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -45,7 +45,7 @@ class DoctrineEntityGenerator extends Generator
             $config->getEntityNamespaces()
         ));
 
-        $entityClass = $this->registry->getEntityNamespace($bundle->getName()).'\\'.$entity;
+        $entityClass = $this->registry->getAliasNamespace($bundle->getName()).'\\'.$entity;
         $entityPath = $bundle->getPath().'/Entity/'.str_replace('\\', '/', $entity).'.php';
         if (file_exists($entityPath)) {
             throw new \RuntimeException(sprintf('Entity "%s" already exists.', $entityClass));


### PR DESCRIPTION
"getEntityNamespace" by "getAliasNamespace"
"getEntityManager" by "getManager"

Missed part of Issue #123
