### PR TITLE
Replace calls to the deprecated Registry::getEntityNamespace

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -99,7 +99,7 @@ EOT
 
         $dialog->writeSection($output, 'CRUD generation');
 
-        $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
+        $entityClass = $this->getContainer()->get('doctrine')->getAliasNamespace($bundle).'\\'.$entity;
         $metadata    = $this->getEntityMetadata($entityClass);
         $bundle      = $this->getContainer()->get('kernel')->getBundle($bundle);
 
@@ -148,7 +148,7 @@ EOT
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
         // Entity exists?
-        $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
+        $entityClass = $this->getContainer()->get('doctrine')->getAliasNamespace($bundle).'\\'.$entity;
         $metadata = $this->getEntityMetadata($entityClass);
 
         // write?

--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -63,7 +63,7 @@ EOT
         $entity = Validators::validateEntityName($input->getArgument('entity'));
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
-        $entityClass = $this->getContainer()->get('doctrine')->getEntityNamespace($bundle).'\\'.$entity;
+        $entityClass = $this->getContainer()->get('doctrine')->getAliasNamespace($bundle).'\\'.$entity;
         $metadata = $this->getEntityMetadata($entityClass);
         $bundle   = $this->getApplication()->getKernel()->getBundle($bundle);
 

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -42,7 +42,7 @@ class DoctrineEntityGenerator extends Generator
         $config = $this->registry->getManager(null)->getConfiguration();
         $config->setEntityNamespaces(array_merge(
             array($bundle->getName() => $bundle->getNamespace().'\\Entity'),
-            $config->getEntityNamespaces()
+            $config->getAliasNamespaces()
         ));
 
         $entityClass = $this->registry->getAliasNamespace($bundle->getName()).'\\'.$entity;

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -130,7 +130,7 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
         $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry
             ->expects($this->any())
-            ->method('getEntityNamespace')
+            ->method('getAliasNamespace')
             ->will($this->returnValue('Foo\\FooBundle\\Entity'))
         ;
 


### PR DESCRIPTION
Replace calls to the deprecated Registry::getEntityNamespace with getAliasNamespace (see doctrine/DoctrineBundle@89c7e1486dcf162ef0b5848209748fcc556e1486).
