### PR TITLE
Fixed deprecated use of Symfony\Component\Form\Form::bind.

### DIFF
--- a/Resources/skeleton/crud/actions/create.php.twig
+++ b/Resources/skeleton/crud/actions/create.php.twig
@@ -18,7 +18,7 @@
 {% block method_body %}
         $entity  = new {{ entity_class }}();
         $form = $this->createForm(new {{ entity_class }}Type(), $entity);
-        $form->bind($request);
+        $form->submit($request);
 
         if ($form->isValid()) {
             $em = $this->getDoctrine()->getManager();

--- a/Resources/skeleton/crud/actions/delete.php.twig
+++ b/Resources/skeleton/crud/actions/delete.php.twig
@@ -16,7 +16,7 @@
     {
 {% block method_body %}
         $form = $this->createDeleteForm($id);
-        $form->bind($request);
+        $form->submit($request);
 
         if ($form->isValid()) {
             $em = $this->getDoctrine()->getManager();

--- a/Resources/skeleton/crud/actions/update.php.twig
+++ b/Resources/skeleton/crud/actions/update.php.twig
@@ -27,7 +27,7 @@
 
         $deleteForm = $this->createDeleteForm($id);
         $editForm = $this->createForm(new {{ entity_class }}Type(), $entity);
-        $editForm->bind($request);
+        $editForm->submit($request);
 
         if ($editForm->isValid()) {
             $em->persist($entity);


### PR DESCRIPTION
Because the method `Symfony\Component\Form\Form::bind` is deprecated since version 2.3, I updated some skeletons to use the new `Symfony\Component\Form\Form::submit` method.
