### PR TITLE
Adding a --no-controller flag to generate:bundle command

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -40,7 +40,7 @@ class GenerateBundleCommand extends GeneratorCommand
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The optional bundle name'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
                 new InputOption('structure', '', InputOption::VALUE_NONE, 'Whether to generate the whole directory structure'),
-                new InputOption('without-controller', '', InputOption::VALUE_NONE, 'Whether to generate an example controller with a first route.'),
+                new InputOption('no-controller', '', InputOption::VALUE_NONE, 'Whether to generate an example controller with a first route.'),
             ))
             ->setDescription('Generates a bundle')
             ->setHelp(<<<EOT
@@ -102,7 +102,7 @@ EOT
         }
         $format = Validators::validateFormat($input->getOption('format'));
         $structure = $input->getOption('structure');
-        $controller = !$input->getOption('without-controller');
+        $withController = !$input->getOption('no-controller');
 
         $dialog->writeSection($output, 'Bundle generation');
 
@@ -111,7 +111,7 @@ EOT
         }
 
         $generator = $this->getGenerator();
-        $generator->generate($namespace, $bundle, $dir, $format, $structure, $controller);
+        $generator->generate($namespace, $bundle, $dir, $format, $structure, $withController);
 
         $output->writeln('Generating the bundle code: <info>OK</info>');
 
@@ -124,7 +124,7 @@ EOT
         // register the bundle in the Kernel class
         $runner($this->updateKernel($dialog, $input, $output, $this->getContainer()->get('kernel'), $namespace, $bundle));
 
-        if ($controller) {
+        if ($withController) {
             // routing
             $runner($this->updateRouting($dialog, $input, $output, $bundle, $format));
         }
@@ -244,13 +244,11 @@ EOT
         }
         $input->setOption('structure', $structure);
 
-        $withoutController = $input->getOption('without-controller');
-        if (!$withoutController && $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate an example controller with a first route?', 'yes', '?'), false)) {
-            $withoutController = false;
-        } else {
-            $withoutController = true;
+        $withController = !$input->getOption('no-controller');
+        if (!$withController && $dialog->askConfirmation($output, $dialog->getQuestion('Do you want to generate an example controller with a first route?', 'yes', '?'), false)) {
+            $withController = true;
         }
-        $input->setOption('without-controller', $withoutController);
+        $input->setOption('no-controller', $withController);
 
         // summary
         $output->writeln(array(

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -28,7 +28,7 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generate($namespace, $bundle, $dir, $format, $structure)
+    public function generate($namespace, $bundle, $dir, $format, $structure, $controller)
     {
         $dir .= '/'.strtr($namespace, '\\', '/');
         if (file_exists($dir)) {
@@ -46,19 +46,23 @@ class BundleGenerator extends Generator
 
         $basename = substr($bundle, 0, -6);
         $parameters = array(
-            'namespace' => $namespace,
-            'bundle'    => $bundle,
-            'format'    => $format,
-            'bundle_basename' => $basename,
-            'extension_alias' => Container::underscore($basename),
+            'namespace'                     => $namespace,
+            'bundle'                        => $bundle,
+            'format'                        => $format,
+            'bundle_basename'               => $basename,
+            'extension_alias'               => Container::underscore($basename),
+            'include_example_controller'    => $controller,
         );
 
         $this->renderFile('bundle/Bundle.php.twig', $dir.'/'.$bundle.'.php', $parameters);
         $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$basename.'Extension.php', $parameters);
         $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
-        $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/DefaultController.php', $parameters);
-        $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
-        $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);
+
+        if ($controller) {
+            $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/DefaultController.php', $parameters);
+            $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
+            $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);
+        }
 
         if ('xml' === $format || 'annotation' === $format) {
             $this->renderFile('bundle/services.xml.twig', $dir.'/Resources/config/services.xml', $parameters);
@@ -66,7 +70,7 @@ class BundleGenerator extends Generator
             $this->renderFile('bundle/services.'.$format.'.twig', $dir.'/Resources/config/services.'.$format, $parameters);
         }
 
-        if ('annotation' != $format) {
+        if ('annotation' != $format && $controller) {
             $this->renderFile('bundle/routing.'.$format.'.twig', $dir.'/Resources/config/routing.'.$format, $parameters);
         }
 

--- a/Resources/skeleton/bundle/routing.php.twig
+++ b/Resources/skeleton/bundle/routing.php.twig
@@ -10,9 +10,11 @@ $collection = new RouteCollection();
 {% endblock definition %}
 
 {% block body %}
+{% if include_example_controller %}
 $collection->add('{{ extension_alias }}_homepage', new Route('/hello/{name}', array(
     '_controller' => '{{ bundle }}:Default:index',
 )));
+{% endif %}
 {% endblock body %}
 
 {% block return %}

--- a/Resources/skeleton/bundle/routing.xml.twig
+++ b/Resources/skeleton/bundle/routing.xml.twig
@@ -5,8 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
 {% block body %}
+    {% if include_example_controller %}
     <route id="{{ extension_alias }}_homepage" pattern="/hello/{name}">
         <default key="_controller">{{ bundle }}:Default:index</default>
     </route>
+    {% endif %}
 {% endblock body %}
 </routes>

--- a/Resources/skeleton/bundle/routing.yml.twig
+++ b/Resources/skeleton/bundle/routing.yml.twig
@@ -1,3 +1,5 @@
+{% if include_example_controller %}
 {{ extension_alias }}_homepage:
     pattern:  /hello/{name}
     defaults: { _controller: {{ bundle }}:Default:index }
+{% endif %}

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -17,7 +17,7 @@ class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
 
         $files = array(
             'FooBarBundle.php',
@@ -44,9 +44,34 @@ class BundleGeneratorTest extends GeneratorTest
         $this->assertContains('Hello {{ name }}!', $content);
     }
 
+    public function testGenerateYamlNoController()
+    {
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
+
+        $files = array(
+            'FooBarBundle.php',
+            'Resources/config/services.yml',
+            'DependencyInjection/Configuration.php',
+            'DependencyInjection/FooBarExtension.php',
+        );
+        $notExistingFiles = array(
+            'Resources/config/routing.yml',
+            'Controller/DefaultController.php',
+            'Resources/views/Default/index.html.twig',
+            'Tests/Controller/DefaultControllerTest.php',
+        );
+
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/Foo/BarBundle/'.$file), sprintf('%s has been generated', $file));
+        }
+        foreach ($notExistingFiles as $file) {
+            $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/'.$file), sprintf('%s has not been generated', $file));
+        }
+    }
+
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false, true);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
@@ -55,13 +80,22 @@ class BundleGeneratorTest extends GeneratorTest
         $this->assertContains('@Route("/hello/{name}"', $content);
     }
 
+    public function testGenerateAnnotationNoController()
+    {
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false, false);
+
+        $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
+        $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
+        $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Controller/DefaultController.php'));
+    }
+
     public function testDirIsFile()
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo');
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -74,7 +108,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -88,7 +122,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -100,7 +134,7 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
     }
 
     protected function getGenerator()


### PR DESCRIPTION
Passing the `--no-controller` flag to the generate:bundle command prevents
that the DefaultController class with an example action is being created. If
no controller class is being created, the routing config file will be omitted
as well and the app's routing config won't be updated.