### PR TITLE
[DX] [CRUD] Added support for entity name autocompletion in the CRUD generator

### DIFF
--- a/Command/AutoComplete/EntitiesAutoCompleter.php
+++ b/Command/AutoComplete/EntitiesAutoCompleter.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Command\AutoComplete;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Provides auto-completion suggestions for entities.
+ *
+ * @author Charles Sarrazin <charles@sarraz.in>
+ */
+class EntitiesAutoCompleter
+{
+    private $manager;
+
+    public function __construct(EntityManagerInterface $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    public function getSuggestions()
+    {
+        $configuration = $this->manager
+            ->getConfiguration()
+        ;
+
+        $namespaceReplacements = array();
+
+        foreach ($configuration->getEntityNamespaces() as $alias => $namespace) {
+            $namespaceReplacements[$namespace.'\\'] = $alias.':';
+        }
+
+        $entities = $configuration
+            ->getMetadataDriverImpl()
+            ->getAllClassNames()
+        ;
+
+        return array_map(function ($entity) use ($namespaceReplacements) {
+            return strtr($entity, $namespaceReplacements);
+        }, $entities);
+    }
+}

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -14,7 +14,6 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\HttpKernel\KernelInterface;

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -15,11 +15,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Sensio\Bundle\GeneratorBundle\Command\AutoComplete\EntitiesAutoCompleter;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineCrudGenerator;
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator;
@@ -159,7 +159,12 @@ EOT
 
         $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getOption('entity')), $input->getOption('entity'));
         $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'));
+
+        $autocompleter = new EntitiesAutoCompleter($this->getContainer()->get('doctrine')->getManager());
+        $autocompleteEntities = $autocompleter->getSuggestions();
+        $question->setAutocompleterValues($autocompleteEntities);
         $entity = $questionHelper->ask($input, $output, $question);
+
         $input->setOption('entity', $entity);
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 

--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -14,7 +14,6 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Command\Command;
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator;
 

--- a/Tests/Command/AutoComplete/EntitiesAutoCompleterTest.php
+++ b/Tests/Command/AutoComplete/EntitiesAutoCompleterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Tests\Command\AutoComplete;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sensio\Bundle\GeneratorBundle\Command\AutoComplete\EntitiesAutoCompleter;
+
+class EntitiesAutoCompleterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getNamespaces
+     */
+    public function testSuggestions($expected, $alias, $classes)
+    {
+        $autoCompleter = new EntitiesAutoCompleter($this->getEntityManagerMock($alias, $classes));
+
+        $this->assertSame($expected, $autoCompleter->getSuggestions());
+    }
+
+    public function getNamespaces()
+    {
+        return array(
+            array(
+                array('AcmeBlogBundle:Post'),
+                array('AcmeBlogBundle' => 'Acme\Bundle\BlogBundle\Entity'),
+                array('Acme\Bundle\BlogBundle\Entity\Post'),
+            ),
+            array(
+                array('AcmeBlogBundle:Blog\Post'),
+                array('AcmeBlogBundle' => 'Acme\Bundle\BlogBundle\Entity'),
+                array('Acme\Bundle\BlogBundle\Entity\Blog\Post'),
+            ),
+            array(
+                array(
+                    'AcmeBlogBundle:Post',
+                    'AcmeCommentBundle:Comment',
+                    'AcmeBlogBundle:Blog\Post',
+                ),
+                array(
+                    'AcmeBlogBundle' => 'Acme\Bundle\BlogBundle\Entity',
+                    'AcmeCommentBundle' => 'Acme\Bundle\CommentBundle\Entity',
+                ),
+                array(
+                    'Acme\Bundle\BlogBundle\Entity\Post',
+                    'Acme\Bundle\CommentBundle\Entity\Comment',
+                    'Acme\Bundle\BlogBundle\Entity\Blog\Post',
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param $aliases
+     * @param $classes
+     *
+     * @return EntityManagerInterface
+     */
+    protected function getEntityManagerMock($aliases, $classes)
+    {
+        $cache = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $cache
+            ->expects($this->any())
+            ->method('getAllClassNames')
+            ->will($this->returnValue($classes))
+        ;
+
+        $configuration = $this->getMock('Doctrine\ORM\Configuration');
+        $configuration
+            ->expects($this->any())
+            ->method('getMetadataDriverImpl')
+            ->will($this->returnValue($cache))
+        ;
+
+        $configuration
+            ->expects($this->any())
+            ->method('getEntityNamespaces')
+            ->will($this->returnValue($aliases))
+        ;
+
+        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager
+            ->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration))
+        ;
+
+        return $manager;
+    }
+}

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -128,15 +128,53 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
     {
         $container = parent::getContainer();
 
+        $container->set('doctrine', $this->getDoctrine());
+
+        return $container;
+    }
+
+    protected function getDoctrine()
+    {
+        $cache = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $cache
+            ->expects($this->any())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array('Acme\Bundle\BlogBundle\Entity\Post')))
+        ;
+
+        $configuration = $this->getMock('Doctrine\ORM\Configuration');
+        $configuration
+            ->expects($this->any())
+            ->method('getMetadataDriverImpl')
+            ->will($this->returnValue($cache))
+        ;
+
+        $configuration
+            ->expects($this->any())
+            ->method('getEntityNamespaces')
+            ->will($this->returnValue(array('AcmeBlogBundle' => 'Acme\Bundle\BlogBundle\Entity')))
+        ;
+
+        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager
+            ->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration))
+        ;
+
         $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry
             ->expects($this->any())
             ->method('getAliasNamespace')
-            ->will($this->returnValue('Foo\\FooBundle\\Entity'))
+            ->will($this->returnValue('Acme\Bundle\BlogBundle\Entity\Blog\Post'))
         ;
 
-        $container->set('doctrine', $registry);
+        $registry
+            ->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($manager))
+        ;
 
-        return $container;
+        return $registry;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As in the doctrine:generate:entity command, there is now support for entity name autocompletion in the form ```VendornameBundlenameBundle:MyEntity```.
Entities are filtered and fetched from the src/ folder and thus, vendor entities are excluded. Repositories are also excluded from the entity list. Autocompletion works well, even entities which are in sub-directories.