### PR TITLE
Remove unnecessary persist call

### DIFF
--- a/Resources/skeleton/crud/actions/update.php.twig
+++ b/Resources/skeleton/crud/actions/update.php.twig
@@ -1,4 +1,3 @@
-
     /**
 {% block phpdoc_method_header %}
      * Edits an existing {{ entity }} entity.
@@ -30,7 +29,6 @@
         $editForm->handleRequest($request);
 
         if ($editForm->isValid()) {
-            $em->persist($entity);
             $em->flush();
 
             return $this->redirect($this->generateUrl('{{ route_name_prefix }}_edit', array('id' => $id)));


### PR DESCRIPTION
From [the documentation](http://symfony.com/doc/current/book/doctrine.html#updating-an-object):

> Notice that calling $em->persist($product) isn't necessary. Recall that this method simply tells Doctrine to manage or "watch" the $product object. In this case, since you fetched the $product object from Doctrine, it's already managed.

Would there be any other reasons to do this call to `persist()` ?
