### PR TITLE
Fix indentation for the `showAction` when annotations are not used

### DIFF
--- a/Resources/skeleton/crud/actions/show.php
+++ b/Resources/skeleton/crud/actions/show.php
@@ -33,7 +33,7 @@
             'entity'      => $entity,
 {% if 'delete' in actions %}
             'delete_form' => $deleteForm->createView(),
-{%- endif %}
+{% endif %}
         ));
 {% endif %}
     }


### PR DESCRIPTION
Before:

```
public function showAction($id)
{
    // ...

    return $this->render('AcmeDemoBundle:Entity:show.html.twig', array(
        'entity'      => $entity,
        'delete_form' => $deleteForm->createView(),        ));
}
```

After:

```
public function showAction($id)
{
    // ...

    return $this->render('AcmeDemoBundle:Entity:show.html.twig', array(
        'entity'      => $entity,
        'delete_form' => $deleteForm->createView(),
    ));
}
```
