### PR TITLE
Use "path" instead of "pattern" in the routing definition generation

### DIFF
--- a/Resources/skeleton/bundle/routing.yml.twig
+++ b/Resources/skeleton/bundle/routing.yml.twig
@@ -1,3 +1,3 @@
 {{ extension_alias }}_homepage:
-    pattern:  /hello/{name}
+    path:  /hello/{name}
     defaults: { _controller: {{ bundle }}:Default:index }


### PR DESCRIPTION
The docs (http://symfony.com/doc/current/book/routing.html) mention `path` as being the new option.
