### PR TITLE
The "--structure" option does not accept a value.

### DIFF
--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -59,10 +59,10 @@ Available Options
 
         php app/console generate:bundle --format=annotation
 
-* ``--structure``: (**no**) [values: yes|no] Whether or not to generate a
+* ``--structure``: If present, generates a
   complete default directory structure including empty public folders for
   documentation, web assets and translations dictionaries:
 
     .. code-block:: bash
 
-        php app/console generate:bundle --structure=yes
+        php app/console generate:bundle --structure


### PR DESCRIPTION
--structure does not allow an argument in bundle version 2.3.4.
