### PR TITLE
Fixed FormCommand to use unified generator interface

### DIFF
--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -66,9 +66,8 @@ EOT
         $entityClass = $this->getContainer()->get('doctrine')->getAliasNamespace($bundle).'\\'.$entity;
         $metadata = $this->getEntityMetadata($entityClass);
         $bundle   = $this->getApplication()->getKernel()->getBundle($bundle);
+        $generator = $this->getGenerator($bundle);
 
-        $generator = new DoctrineFormGenerator($this->getContainer()->get('filesystem'));
-        $generator->setSkeletonDirs($this->getSkeletonDirs($bundle));
         $generator->generate($bundle, $entity, $metadata[0]);
 
         $output->writeln(sprintf(


### PR DESCRIPTION
It had hardcoded DoctrineFormGenerator instance creation, instead of unified generator interface usage.
