### PR TITLE
[Bugfix] Added support for better bundle inheritance

### DIFF
--- a/Command/GeneratorCommand.php
+++ b/Command/GeneratorCommand.php
@@ -55,7 +55,23 @@ abstract class GeneratorCommand extends ContainerAwareCommand
             $skeletonDirs[] = $dir;
         }
 
-        $skeletonDirs[] = __DIR__.'/../Resources/skeleton';
+
+        $bundleDirs = $this->getContainer()->get('kernel')
+            ->locateResource('@SensioGeneratorBundle/Resources/skeleton', null, false);
+        $sensioGeneratorSkeletonPath=dirname(__DIR__).'/Resources/skeleton';
+        
+        /*
+         * Assert: $bundleDirs is an array that contains $sensioGeneratorSkeletonPath and maybe some more
+         * Since $skeletonDirs is a prioritized list we want to exclude $sensioGeneratorSkeletonPath from $bundleDirs
+         * now and make sure it is added at the end of the list.
+         */
+        foreach ($bundleDirs as $dir) {
+            if ($dir != $sensioGeneratorSkeletonPath) {
+                $skeletonDirs[] = $dir;
+            }
+        }
+
+        $skeletonDirs[] = $sensioGeneratorSkeletonPath;
         $skeletonDirs[] = __DIR__.'/../Resources';
 
         return $skeletonDirs;

--- a/Tests/Command/GeneratorCommandTest.php
+++ b/Tests/Command/GeneratorCommandTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Tests\Command;
+
+use Sensio\Bundle\GeneratorBundle\Command\GeneratorCommand;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class GeneratorCommandTest extends GenerateCommandTest
+{
+    public function testGetSkeletonDirs()
+    {
+        $container=$this->getContainer();
+        $kernel=$container->get('kernel');
+
+        /*
+         * Get some paths to possible skeleton dirs
+         */
+        $skeletonResources=array(
+            '/path/Acme/DemoBundle/Resources/skeleton',
+            //the path to this bundle's skeletons
+            dirname(dirname(__DIR__)).'/Resources/skeleton',
+            '/path/ZMan/GeneratorBundle/Resources/skeleton',
+        );
+
+        $kernel
+            ->expects($this->once())
+            ->method('locateResource')
+            ->will($this->returnValue($skeletonResources))
+        ;
+        $container->set('kernel', $kernel);
+
+        $generator = new GeneratorCommandDummy();
+        $generator->setContainer($container);
+
+        $dirs=$generator->getSkeletonDirs();
+
+        $prioritizedSkeletonResources=array(
+            '/path/Acme/DemoBundle/Resources/skeleton',
+            '/path/ZMan/GeneratorBundle/Resources/skeleton',
+            //This should be the last one
+            dirname(dirname(__DIR__)).'/Resources/skeleton',
+        );
+
+        $this->assertEquals($prioritizedSkeletonResources, array_slice($dirs, 0, 3));
+
+    }
+}
+
+class GeneratorCommandDummy extends GeneratorCommand
+{
+    public function getSkeletonDirs(BundleInterface $bundle = null)
+    {
+        return parent::getSkeletonDirs($bundle);
+    }
+
+    public function configure()
+    {
+        $this->setName('GeneratorCommandDummy');
+    }
+
+    public function createGenerator()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
This update allows users to create a bundle that contains the skeleton templates. 

This functionality was mentioned in Issue #233. 

### Use case
When you want to have a MyCompanyGeneratorBundle that you use for all the projects in your company. Just make sure to set SensioGeneratorBundle as "parent" in the bundle class definition. 
