### PR TITLE
make the force overwrite flag also overwrite generated forms when generating crud

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -114,7 +114,7 @@ EOT
 
         // form
         if ($withWrite) {
-            $this->generateForm($bundle, $entity, $metadata);
+            $this->generateForm($bundle, $entity, $metadata, $forceOverwrite);
             $output->writeln('Generating the Form code: <info>OK</info>');
         }
 
@@ -194,13 +194,9 @@ EOT
     /**
      * Tries to generate forms if they don't exist yet and if we need write operations on entities.
      */
-    protected function generateForm($bundle, $entity, $metadata)
+    protected function generateForm($bundle, $entity, $metadata, $forceOverwrite)
     {
-        try {
-            $this->getFormGenerator($bundle)->generate($bundle, $entity, $metadata[0]);
-        } catch (\RuntimeException $e ) {
-            // form already exists
-        }
+        $this->getFormGenerator($bundle)->generate($bundle, $entity, $metadata[0],$forceOverwrite);
     }
 
     protected function updateRouting(DialogHelper $dialog, InputInterface $input, OutputInterface $output, BundleInterface $bundle, $format, $entity, $prefix)

--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -54,7 +54,7 @@ class DoctrineFormGenerator extends Generator
      * @param string            $entity   The entity relative class name
      * @param ClassMetadataInfo $metadata The entity metadata class
      */
-    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata)
+    public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata,$forceOverwrite)
     {
         $parts       = explode('\\', $entity);
         $entityClass = array_pop($parts);
@@ -63,7 +63,7 @@ class DoctrineFormGenerator extends Generator
         $dirPath         = $bundle->getPath().'/Form';
         $this->classPath = $dirPath.'/'.str_replace('\\', '/', $entity).'Type.php';
 
-        if (file_exists($this->classPath)) {
+        if (!$forceOverwrite && file_exists($this->classPath)) {
             throw new \RuntimeException(sprintf('Unable to generate the %s form class as it already exists under the %s file', $this->className, $this->classPath));
         }
 

--- a/Tests/Generator/DoctrineFormGeneratorTest.php
+++ b/Tests/Generator/DoctrineFormGeneratorTest.php
@@ -28,7 +28,7 @@ class DoctrineFormGeneratorTest extends GeneratorTest
         $metadata->identifier = array('id');
         $metadata->associationMappings = array('title' => array('type' => 'string'));
 
-        $generator->generate($bundle, 'Post', $metadata);
+        $generator->generate($bundle, 'Post', $metadata,true);
 
         $this->assertTrue(file_exists($this->tmpDir.'/Form/PostType.php'));
 


### PR DESCRIPTION
Modification so that using the force overwrite flag will make the generator overwrite form classes as well as the controller

Without the flag an exception will be thrown and displayed to the user (rather than silently caught) if a form class already exists. They can then decide to run with force overwrite or take any other action 
