### PR TITLE
Fixed creating actions from command-line

### DIFF
--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -171,7 +171,7 @@ EOT
         $input->setOption('route-format', $routeFormat);
 
         // templating format
-        $validateTemplateFormat = function($format) {
+        $validateTemplateFormat = function ($format) {
             if (!in_array($format, array('twig', 'php'))) {
                 throw new \InvalidArgumentException(sprintf('The template format must be twig or php, "%s" given', $format));
             }
@@ -212,7 +212,7 @@ EOT
             '',
         ));
 
-        $templateNameValidator = function($name) {
+        $templateNameValidator = function ($name) {
             if ('default' == $name) {
                 return $name;
             }

--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -270,13 +270,21 @@ EOT
 
     public function parseActions($actions)
     {
-        if (is_array($actions)) {
+        if (empty($actions) || $actions !== array_values($actions)) {
             return $actions;
+        }
+
+        $actionList = array();
+
+        if (1 == count($actions)) {
+            $actionList = explode(' ', $actions[0]);
+        } else {
+            $actionList = $actions;
         }
 
         $newActions = array();
 
-        foreach (explode(' ', $actions) as $action) {
+        foreach ($actionList as $action) {
             $data = explode(':', $action);
 
             // name

--- a/Tests/Command/GenerateControllerCommandTest.php
+++ b/Tests/Command/GenerateControllerCommandTest.php
@@ -64,7 +64,7 @@ class GenerateControllerCommandTest extends GenerateCommandTest
                 ),
             ))),
 
-            array(array('--route-format' => 'xml', '--template-format' => 'php', '--actions' => 'showAction:/{slug}:AcmeBlogBundle:article.html.php'), 'AcmeBlogBundle:Post', array('Post', 'xml', 'php', array(
+            array(array('--route-format' => 'xml', '--template-format' => 'php', '--actions' => array('showAction:/{slug}:AcmeBlogBundle:article.html.php')), 'AcmeBlogBundle:Post', array('Post', 'xml', 'php', array(
                 'showAction' => array(
                     'name' => 'showAction',
                     'route' => '/{slug}',
@@ -100,7 +100,7 @@ class GenerateControllerCommandTest extends GenerateCommandTest
         return array(
             array(array('--controller' => 'AcmeBlogBundle:Post'), array('Post', 'annotation', 'twig', array())),
             array(array('--controller' => 'AcmeBlogBundle:Post', '--route-format' => 'yml', '--template-format' => 'php'), array('Post', 'yml', 'php', array())),
-            array(array('--controller' => 'AcmeBlogBundle:Post', '--actions' => 'showAction getListAction:/_getlist/{max}:AcmeBlogBundle:List:post.html.twig createAction:/admin/create'), array('Post', 'annotation', 'twig', array(
+            array(array('--controller' => 'AcmeBlogBundle:Post', '--actions' => array('showAction getListAction:/_getlist/{max}:AcmeBlogBundle:List:post.html.twig createAction:/admin/create')), array('Post', 'annotation', 'twig', array(
                 'showAction' => array(
                     'name' => 'showAction',
                     'route' => '/show',
@@ -120,7 +120,7 @@ class GenerateControllerCommandTest extends GenerateCommandTest
                     'template' => 'default',
                 ),
             ))),
-            array(array('--controller' => 'AcmeBlogBundle:Post', '--route-format' => 'xml', '--template-format' => 'php', '--actions' => 'showAction::'), array('Post', 'xml', 'php', array(
+            array(array('--controller' => 'AcmeBlogBundle:Post', '--route-format' => 'xml', '--template-format' => 'php', '--actions' => array('showAction::')), array('Post', 'xml', 'php', array(
                 'showAction' => array(
                     'name' => 'showAction',
                     'route' => '/show',


### PR DESCRIPTION
<table>
<thead><tr>
<th>Q</th>
<th>A</th>
</tr></thead>
<tbody>
<tr>
<td>Bug fix?</td>
<td>yes</td>
</tr>
<tr>
<td>New feature?</td>
<td>no</td>
</tr>
<tr>
<td>BC breaks?</td>
<td>no</td>
</tr>
<tr>
<td>Deprecations?</td>
<td>no</td>
</tr>
<tr>
<td>Tests pass?</td>
<td>yes</td>
</tr>
<tr>
<td>License</td>
<td>MIT</td>
</tr>
</tbody>
</table>

Fixed generating controller from command-line with option `--actions`