### PR TITLE
Update crud generation with fields definitions WIP

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -251,6 +251,7 @@ class DoctrineCrudGenerator extends Generator
         $this->renderFile('crud/views/new.html.twig.twig', $dir.'/new.html.twig', array(
             'bundle'            => $this->bundle->getName(),
             'entity'            => $this->entity,
+            'fields'            => $this->metadata->fieldMappings,
             'route_prefix'      => $this->routePrefix,
             'route_name_prefix' => $this->routeNamePrefix,
             'actions'           => $this->actions,
@@ -268,6 +269,7 @@ class DoctrineCrudGenerator extends Generator
             'route_prefix'      => $this->routePrefix,
             'route_name_prefix' => $this->routeNamePrefix,
             'entity'            => $this->entity,
+            'fields'            => $this->metadata->fieldMappings,
             'bundle'            => $this->bundle->getName(),
             'actions'           => $this->actions,
         ));


### PR DESCRIPTION
For many sites, it is impossible to use the form twig method only.

Defined each fields with custom html markup is necessary.

Without this change it is impossible to just overwrite template, and the only solution is to recreate another command, so add fields to all generation function permit to simply use twig template inheritence without hard coding many codes.

This change was human tested, it work.