### PR TITLE
Fixed form indentation

### DIFF
--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -13,7 +13,7 @@ class {{ form_class }} extends AbstractType
 {% endblock class_definition %}
 {
 {% block class_body %}
-    {% if fields|length > 0 %}
+    {%- if fields|length > 0 %}
     /**
      * @param FormBuilderInterface $builder
      * @param array $options


### PR DESCRIPTION
The code generated looks like:

```
class AbcType extends AbstractType
{
        /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
```

With the fix:

```
class AbcType extends AbstractType
{
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
```
