### PR TITLE
changed the label button to match with the label button used in the edit.php.twig

### DIFF
--- a/Resources/skeleton/crud/tests/others/full_scenario.php.twig
+++ b/Resources/skeleton/crud/tests/others/full_scenario.php.twig
@@ -24,7 +24,7 @@
         // Edit the entity
         $crawler = $client->click($crawler->selectLink('Edit')->link());
 
-        $form = $crawler->selectButton('Edit')->form(array(
+        $form = $crawler->selectButton('Update')->form(array(
             '{{ form_type_name|lower }}[field_name]'  => 'Foo',
             // ... other fields to fill
         ));


### PR DESCRIPTION
Changed the label button to 'Update' to match with the label button generated by the edit.php.twig class.

The test class search by a button 'Edit', but the name generated by twig skeleton is 'Update'.
