### PR TITLE
[DX] Do not use parameters in generate:bundle service file

### DIFF
--- a/Resources/skeleton/bundle/services.xml.twig
+++ b/Resources/skeleton/bundle/services.xml.twig
@@ -5,15 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <!--
-    <parameters>
-{% block parameters %}
-        <parameter key="{{ extension_alias }}.example.class">{{ namespace }}\Example</parameter>
-{% endblock parameters %}
-    </parameters>
-
     <services>
 {% block services %}
-        <service id="{{ extension_alias }}.example" class="%{{ extension_alias }}.example.class%">
+        <service id="{{ extension_alias }}.example" class="{{ namespace }}\Example">
             <argument type="service" id="service_id" />
             <argument>plain_value</argument>
             <argument>%parameter_name%</argument>

--- a/Resources/skeleton/bundle/services.yml.twig
+++ b/Resources/skeleton/bundle/services.yml.twig
@@ -1,11 +1,6 @@
-parameters:
-{% block parameters %}
-#    {{ extension_alias }}.example.class: {{ namespace }}\Example
-{% endblock parameters %}
-
 services:
 {% block services %}
 #    {{ extension_alias }}.example:
-#        class: %{{ extension_alias }}.example.class%
+#        class: {{ namespace }}\Example
 #        arguments: [@service_id, "plain_value", %parameter%]
 {% endblock services %}

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -42,6 +42,31 @@ class BundleGeneratorTest extends GeneratorTest
 
         $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Resources/views/Default/index.html.twig');
         $this->assertContains('Hello {{ name }}!', $content);
+
+        $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Resources/config/services.yml');
+        $this->assertContains('class: Foo\BarBundle\Example', $content);
+    }
+
+    public function testGenerateXml()
+    {
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false);
+
+        $files = array(
+            'FooBarBundle.php',
+            'Controller/DefaultController.php',
+            'Resources/views/Default/index.html.twig',
+            'Resources/config/routing.xml',
+            'Tests/Controller/DefaultControllerTest.php',
+            'Resources/config/services.xml',
+            'DependencyInjection/Configuration.php',
+            'DependencyInjection/FooBarExtension.php',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/Foo/BarBundle/'.$file), sprintf('%s has been generated', $file));
+        }
+
+        $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Resources/config/services.xml');
+        $this->assertContains('<service id="foo_bar.example" class="Foo\BarBundle\Example">', $content);
     }
 
     public function testGenerateAnnotation()


### PR DESCRIPTION
Remove parameters generated by the generate:bundle command

Related to https://github.com/sensiolabs/SensioGeneratorBundle/issues/285
