### PR TITLE
Services configuration format choice for bundle generation with the 'annotation' format

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -266,11 +266,15 @@ EOT
         $input->setOption('structure', $structure);
 
         // summary
+        $services = '';
+        if ($servicesFormat != $format) {
+            $services = sprintf(" (\"<info>%s</info>\" format for the services)", $servicesFormat);
+        }
         $output->writeln(array(
             '',
             $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg=white', true),
             '',
-            sprintf("You are going to generate a \"<info>%s\\%s</info>\" bundle\nin \"<info>%s</info>\" using the \"<info>%s</info>\" format.", $namespace, $bundle, $dir, $format),
+            sprintf("You are going to generate a \"<info>%s\\%s</info>\" bundle\nin \"<info>%s</info>\" using the \"<info>%s</info>\" format%s.", $namespace, $bundle, $dir, $format, $services),
             '',
         ));
     }

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -39,6 +39,7 @@ class GenerateBundleCommand extends GeneratorCommand
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle'),
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The optional bundle name'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
+                new InputOption('services-format', '', InputOption::VALUE_REQUIRED, 'Use the format for services configuration file (php, xml, or yml)'),
                 new InputOption('structure', '', InputOption::VALUE_NONE, 'Whether to generate the whole directory structure'),
             ))
             ->setDescription('Generates a bundle')
@@ -100,6 +101,13 @@ EOT
             $input->setOption('format', 'annotation');
         }
         $format = Validators::validateFormat($input->getOption('format'));
+        if (null === $input->getOption('services-format')) {
+            $input->setOption('services-format', $input->getOption('format'));
+        }
+        if ('annotation' === $input->getOption('services-format')) {
+            $input->setOption('services-format', 'yml');
+        }
+        $servicesFormat = Validators::validateServicesFormat($input->getOption('services-format'));
         $structure = $input->getOption('structure');
 
         $dialog->writeSection($output, 'Bundle generation');
@@ -109,7 +117,7 @@ EOT
         }
 
         $generator = $this->getGenerator();
-        $generator->generate($namespace, $bundle, $dir, $format, $structure);
+        $generator->generate($namespace, $bundle, $dir, $format, $servicesFormat, $structure);
 
         $output->writeln('Generating the bundle code: <info>OK</info>');
 

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -234,6 +234,23 @@ EOT
             $input->setOption('format', $format);
         }
 
+        $servicesFormat = null;
+        try {
+            $servicesFormat = $input->getOption('services-format') ? Validators::validateServicesFormat($input->getOption('services-format')) : $format;
+        } catch (\Exception $error) {
+            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        }
+
+        if (null === $servicesFormat || 'annotation' == $servicesFormat) {
+            $output->writeln(array(
+                '',
+                'Determine the format to use for the generated services configuration.',
+                '',
+            ));
+            $servicesFormat = $dialog->askAndValidate($output, $dialog->getQuestion('Services configuration format (yml, xml, or php)', $input->getOption('services-format')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateServicesFormat'), false, $input->getOption('services-format'));
+            $input->setOption('services-format', $servicesFormat);
+        }
+
         // optional files to generate
         $output->writeln(array(
             '',

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -54,7 +54,7 @@ class Validators
         if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $bundle)) {
             throw new \InvalidArgumentException('The bundle name contains invalid characters.');
         }
-        
+
         if (!preg_match('/Bundle$/', $bundle)) {
             throw new \InvalidArgumentException('The bundle name must end with Bundle.');
         }

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -95,6 +95,17 @@ class Validators
         return $format;
     }
 
+    public static function validateServicesFormat($format)
+    {
+        $format = strtolower($format);
+
+        if (!in_array($format, array('php', 'xml', 'yml'))) {
+            throw new \RuntimeException(sprintf('Format "%s" is not supported for services.', $format));
+        }
+
+        return $format;
+    }
+
     public static function validateEntityName($entity)
     {
         if (false === strpos($entity, ':')) {

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -28,7 +28,7 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generate($namespace, $bundle, $dir, $format, $structure)
+    public function generate($namespace, $bundle, $dir, $format, $servicesFormat, $structure)
     {
         $dir .= '/'.strtr($namespace, '\\', '/');
         if (file_exists($dir)) {
@@ -49,6 +49,7 @@ class BundleGenerator extends Generator
             'namespace' => $namespace,
             'bundle'    => $bundle,
             'format'    => $format,
+            'services_format' => $servicesFormat,
             'bundle_basename' => $basename,
             'extension_alias' => Container::underscore($basename),
         );
@@ -60,11 +61,7 @@ class BundleGenerator extends Generator
         $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
         $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);
 
-        if ('xml' === $format || 'annotation' === $format) {
-            $this->renderFile('bundle/services.xml.twig', $dir.'/Resources/config/services.xml', $parameters);
-        } else {
-            $this->renderFile('bundle/services.'.$format.'.twig', $dir.'/Resources/config/services.'.$format, $parameters);
-        }
+        $this->renderFile('bundle/services.'.$servicesFormat.'.twig', $dir.'/Resources/config/services.'.$servicesFormat, $parameters);
 
         if ('annotation' != $format) {
             $this->renderFile('bundle/routing.'.$format.'.twig', $dir.'/Resources/config/routing.'.$format, $parameters);

--- a/Resources/skeleton/bundle/Extension.php.twig
+++ b/Resources/skeleton/bundle/Extension.php.twig
@@ -29,13 +29,13 @@ class {{ bundle_basename }}Extension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        {% if format == 'yml' -%}
+        {% if services_format == 'yml' -%}
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
-        {%- elseif format == 'xml' or format == 'annotation' -%}
+        {%- elseif services_format == 'xml' -%}
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
-        {%- elseif format == 'php' -%}
+        {%- elseif services_format == 'php' -%}
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.php');
         {%- endif %}

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -21,13 +21,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testInteractiveCommand($options, $input, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($namespace, $bundle, $dir, $format, $servicesFormat, $structure) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure)
+            ->with($namespace, $bundle, $dir, $format, $servicesFormat, $structure)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -39,9 +39,9 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array(), "Foo/BarBundle\nBarBundle\nfoo\nyml\nn", array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--dir' => $tmp, '--format' => 'annotation', '--services-format' => 'yml'), "Foo/BarBundle\n", array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', 'yml', false)),
+            array(array(), "Foo/BarBundle\nBarBundle\nfoo\nyml\nn", array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', 'yml', false)),
+            array(array('--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', 'yml', true)),
         );
     }
 
@@ -50,13 +50,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testNonInteractiveCommand($options, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($namespace, $bundle, $dir, $format, $servicesFormat, $structure) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure)
+            ->with($namespace, $bundle, $dir, $format, $servicesFormat, $structure)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, ''));
@@ -68,8 +68,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', 'yml', false)),
+            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', 'yml', true)),
         );
     }
 

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -17,7 +17,7 @@ class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', 'yml', false);
 
         $files = array(
             'FooBarBundle.php',
@@ -49,7 +49,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateXml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', 'xml', false);
 
         $files = array(
             'FooBarBundle.php',
@@ -71,10 +71,12 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', 'yml', false);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
+
+        $this->assertTrue(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/services.yml'), 'services.yml has been generated');
 
         $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Controller/DefaultController.php');
         $this->assertContains('@Route("/hello/{name}"', $content);
@@ -86,7 +88,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -99,7 +101,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -113,7 +115,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -125,7 +127,7 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', 'yml', false);
     }
 
     protected function getGenerator()


### PR DESCRIPTION
When you chose 'annotation' as the generated configuration files format, 'xml' is used for the services configuration file and there is no way to chose another format.

With this patch, when 'annotation' is chosen, the user will be asked to chose a format for the services configuration.

I'm not quite sure about the etiquette with pull-requests here (maybe I should open an issue first ?), and this patch might not be really elegant, but here is my proposition anyway :-)
