### PR TITLE
[DX] Improving generate:doctrine:crud #293

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -235,6 +235,8 @@ EOT
 
     protected function getEntitiesList()
     {
+
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
         $entityManager = $this->getContainer()->get('doctrine')->getManager();
         $entityClassNames = $entityManager->getConfiguration()
                                       ->getMetadataDriverImpl()
@@ -248,13 +250,13 @@ EOT
         }
 
         $entityShortNames = array();
-        $namespacesMap = $entityManager->getConfiguration()->getEntityNamespaces();
+        $entityNamespaceMap = $entityManager->getConfiguration()->getEntityNamespaces();
+
         foreach ($entityClassNames as $entityClassName) {
-            foreach ($namespacesMap as $alias => $namespace) {
+            foreach ($entityNamespaceMap as $shortNotationBundleName => $namespace) {
                 if (false !== strpos($entityClassName, $namespace)) {
-                    $shortNotationBundleNamespace = $alias;
-                    $entityShortNamespaceLessName = str_replace($namespace . '\\', '', $entityClassName);
-                    $entityShortNames[] = $shortNotationBundleNamespace . ':' . $entityShortNamespaceLessName;
+                    $onBundleEntityPath = str_replace($namespace . '\\', '', $entityClassName);
+                    $entityShortNames[] = $shortNotationBundleName . ':' . $onBundleEntityPath;
                 }
             }
         }

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -134,7 +134,6 @@ EOT
         $dialog = $this->getDialogHelper();
         $dialog->writeSection($output, 'Welcome to the Doctrine2 CRUD generator');
 
-
         $output->writeln(array(
             '',
             'This command helps you generate CRUD controllers and templates.',
@@ -145,6 +144,11 @@ EOT
 
         $withList = $input->getOption('with-list');
         if ($withList) {
+            $output->writeln(array(
+                'First, you need to give the entity for which you want to generate a CRUD.',
+                ''
+            ));
+
             $output->writeln(sprintf("Found <info>%d</info> mapped entities:", count($entityShortNames)));
 
             $counter = 0;
@@ -154,7 +158,8 @@ EOT
                 $counter++;
             }
 
-            $entityNumber = $dialog->ask($output, 'Choose entity number:');
+            $output->writeln('');
+            $entityNumber = $dialog->ask($output, 'Enter the number of the entity from the list above:');
             if (array_key_exists($entityNumber, $entityShortNames)) {
                 $entity = $entityShortNames[$entityNumber];
             } else {
@@ -167,9 +172,6 @@ EOT
         } else {
             // namespace
             $output->writeln(array(
-                '',
-                'This command helps you generate CRUD controllers and templates.',
-                '',
                 'First, you need to give the entity for which you want to generate a CRUD.',
                 'You can give an entity that does not exist yet and the wizard will help',
                 'you defining it.',

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -184,7 +184,7 @@ EOT
                 $input->setOption('entity', $input->getArgument('entity'));
             }
 
-            $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'));
+            $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'), $entityShortNames);
         }
 
         $input->setOption('entity', $entity);

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -235,7 +235,7 @@ EOT
 
     protected function getEntitiesList()
     {
-        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager = $this->getContainer()->get('doctrine')->getManager();
         $entityClassNames = $entityManager->getConfiguration()
                                       ->getMetadataDriverImpl()
                                       ->getAllClassNames();

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -163,6 +163,7 @@ EOT
                 );
             }
 
+            $output->writeln(array('', $this->getHelper('formatter')->formatBlock(sprintf('Generating CRUD for entity %s', $entity), 'bg=blue;fg=white', true), ''));
         } else {
             // namespace
             $output->writeln(array(
@@ -232,7 +233,7 @@ EOT
 
     protected function getEntitiesList()
     {
-        $entityManager = $this->getContainer()->get('doctrine')->getManager();
+        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
         $entityClassNames = $entityManager->getConfiguration()
                                       ->getMetadataDriverImpl()
                                       ->getAllClassNames();
@@ -245,10 +246,15 @@ EOT
         }
 
         $entityShortNames = array();
+        $namespacesMap = $entityManager->getConfiguration()->getEntityNamespaces();
         foreach ($entityClassNames as $entityClassName) {
-            $path = explode('\Entity\\', $entityClassName);
-            $shortName = str_replace('\\', '', $path[0]).':'.$path[1];
-            $entityShortNames[] = $shortName;
+            foreach ($namespacesMap as $alias => $namespace) {
+                if (false !== strpos($entityClassName, $namespace)) {
+                    $shortNotationBundleNamespace = $alias;
+                    $entityShortNamespaceLessName = str_replace($namespace . '\\', '', $entityClassName);
+                    $entityShortNames[] = $shortNotationBundleNamespace . ':' . $entityShortNamespaceLessName;
+                }
+            }
         }
 
         return $entityShortNames;

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -132,8 +132,34 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
         $registry
             ->expects($this->any())
             ->method('getAliasNamespace')
-            ->will($this->returnValue('Foo\\FooBundle\\Entity'))
-        ;
+            ->will($this->returnValue('Foo\\FooBundle\\Entity'));
+
+        $mappingDriver = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver');
+        $mappingDriver
+            ->expects($this->any())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array('Acme\\BlogBundle\\Entity\\Blog\\Post')));
+
+        $configuration = $this->getMock('Doctrine\\ORM\\Configuration');
+        $configuration
+            ->expects($this->any())
+            ->method('getMetadataDriverImpl')
+            ->will($this->returnValue($mappingDriver));
+        $configuration
+            ->expects($this->any())
+            ->method('getEntityNamespaces')
+            ->will($this->returnValue(array('AcmeBlogBundle' => 'Acme\\BlogBundle\\Entity')));
+
+        $manager = $this->getMock('Doctrine\\ORM\\EntityManagerInterface');
+        $manager
+            ->expects($this->any())
+            ->method('getConfiguration')
+            ->will($this->returnValue($configuration));
+
+        $registry
+            ->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($manager));
 
         $container->set('doctrine', $registry);
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sensio/generator-bundle",
+    "name": "sergiofg/generator-bundle",
     "description": "This bundle generates code for you",
     "keywords": [],
     "type": "symfony-bundle",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sergiofg/generator-bundle",
+    "name": "sensio/generator-bundle",
     "description": "This bundle generates code for you",
     "keywords": [],
     "type": "symfony-bundle",


### PR DESCRIPTION
Improve "generate:doctrine:crud" command adding two features:
    - Add option "--with-list", which shown a list of all available entities with an index. User should select one and then proceed with generation of the CRUD.
    - Add auto-completion when user inserts entity name. 

| Q                       | A
| -------------          | ---
| Bug fix?             | no
| New feature?    | yes
| BC breaks?       | no
| Deprecations?  | no
| Tests pass?      | yes
| Fixed tickets      |
| License             | MIT
| Doc PR             |