### PR TITLE
[console] Fix bundle selection in controller generation

### DIFF
--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -88,7 +88,8 @@ EOT
             $bundle = Validators::validateBundleName($bundle);
 
             try {
-                $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
+                $bundleMap = $this->getContainer()->get('kernel')->getBundle($bundle, false);
+                $bundle = end($bundleMap);
             } catch (\Exception $e) {
                 $output->writeln(sprintf('<bg=red>Bundle "%s" does not exist.</>', $bundle));
             }
@@ -125,7 +126,8 @@ EOT
             list($bundle, $controller) = $this->parseShortcutNotation($controller);
 
             try {
-                $b = $this->getContainer()->get('kernel')->getBundle($bundle);
+                $bundleMap = $this->getContainer()->get('kernel')->getBundle($bundle, false);
+                $b = end($bundleMap);
 
                 if (!file_exists($b->getPath().'/Controller/'.$controller.'Controller.php')) {
                     break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        |

When generating a new controller for a bundle which has derivations (another bundle inherits from this bundle), the function ``getBundle()`` executed from kernel will return the child. Consequently the controller will be created in the wrong bundle.

[The kernel comments](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Kernel.php#L464) state, that the order of the bundleMap hierarchy is ``most derived bundle first``. Without the ``false`` flag, the function ``getBundle`` will only return the first element. The PR simply chooses the last element.

I'm not sure if [#297](https://github.com/sensiolabs/SensioGeneratorBundle/issues/297) is relating to this problem, however i've seen the ``getBundle`` command in the ``\Command\Helper\GenerateDoctrineCrudCommand.php`` class as well. Unfortunately I don't have the time right now to check this.

//edit: I'm a little confused why the unit test fails.. help would be appreciated!