### PR TITLE
 GenerateDoctrineCrudCommand:generateForm() silently fails when the form...

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -115,13 +115,13 @@ EOT
         $runner = $dialog->getRunner($output, $errors);
 
         // form
-        if ($withWrite) {            
+        if ($withWrite) {
             $output->write('Generating the Form code: ');
-	    if ($this->generateForm($bundle, $entity, $metadata)) {
-		$output->writeln('<info>OK</info>');
-	    } else {
-		$output->writeln('<warning>Already exists, skipping</warning>');
-	    }
+            if ($this->generateForm($bundle, $entity, $metadata)) {
+                $output->writeln('<info>OK</info>');
+            } else {
+                $output->writeln('<warning>Already exists, skipping</warning>');
+            }
         }
 
         // routing


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #304 |
| License | MIT |
| Doc PR | SensioGeneratorBundle#304 |
