### PR TITLE
Enable the possibility to extends the twig environment

### DIFF
--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -44,7 +44,8 @@ class Generator
      * Get the twig environment that will render skeletons
      * @return \Twig_Environment
      */
-    protected function getTwigEnvironment(){
+    protected function getTwigEnvironment()
+    {
         return new \Twig_Environment(new \Twig_Loader_Filesystem($this->skeletonDirs), array(
             'debug'            => true,
             'cache'            => false,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #208 |

This PR allow people who extends the generator for custom use to alter the twig environment. 

For example, it will allow to add an extension :

``` php
class MyGenerator extends Generator 
{
   protected function getTwigEnvironment(){
      $twig = parent::getTwigEnvironment();
      $twig->addExtension( new MyTwigExtension() );
      return $twig;
   }
}
```
