### PR TITLE
Update generate:bundle for non-shared bundles and more

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -40,7 +40,7 @@ class GenerateBundleCommand extends GeneratorCommand
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle'),
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The optional bundle name'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
-                new InputOption('shared', '', InputOption::VALUE_NONE, 'Are you planning on using/sharing this bundle across multiple applications?'),
+                new InputOption('shared', '', InputOption::VALUE_NONE, 'Are you planning on sharing this bundle across multiple applications?'),
             ))
             ->setDescription('Generates a bundle')
             ->setHelp(<<<EOT
@@ -54,7 +54,7 @@ conventions):
 <info>php app/console generate:bundle --namespace=Acme/BlogBundle</info>
 
 Note that you can use <comment>/</comment> instead of <comment>\\ </comment>for the namespace delimiter to avoid any
-problem.
+problems.
 
 If you want to disable any user interaction, use <comment>--no-interaction</comment> but don't forget to pass all needed options:
 
@@ -130,14 +130,14 @@ EOT
     protected function interact(InputInterface $input, OutputInterface $output)
     {
         $dialog = $this->getDialogHelper();
-        $dialog->writeSection($output, 'Welcome to the Symfony2 bundle generator!');
+        $dialog->writeSection($output, 'Welcome to the Symfony bundle generator!');
 
         /*
          * shared option
          */
         $shared = $input->getOption('shared');
 
-        if (!$shared && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on using/sharing this bundle across multiple applications?', 'no'), false)) {
+        if (!$shared && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on sharing this bundle across multiple applications?', 'no'), false)) {
             $shared = true;
         }
 
@@ -186,7 +186,7 @@ EOT
             } else {
                 // a simple application bundle
                 $output->writeln(array(
-                    'Given your bundle a descriptive name, like <comment>BlogBundle</comment>.',
+                    'Give your bundle a descriptive name, like <comment>BlogBundle</comment>.',
                 ));
 
                 $namespace = $dialog->askAndValidate(
@@ -282,26 +282,6 @@ EOT
             );
             $input->setOption('format', $format);
         }
-
-        // summary
-        $output->writeln(array(
-            '',
-            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg=white', true),
-            '',
-            sprintf(
-                "We're about to generate a <info>%s</info> bundle into the \"<info>%s</info>\"\ndirectory using the \"<info>%s</info>\" configuration format.",
-                $bundle,
-                $this->makePathRelative($dir),
-                $format
-            ),
-            '',
-        ));
-
-        if (!$dialog->askConfirmation($output, $dialog->getQuestion('Does this all sound ok to you', 'yes', '?'), true)) {
-            $output->writeln('<error>Command aborted</error>');
-
-            return 1;
-        }
     }
 
     protected function checkAutoloader(OutputInterface $output, $namespace, $bundle, $dir)
@@ -319,9 +299,9 @@ EOT
     protected function updateKernel(QuestionHelper $questionHelper, InputInterface $input, OutputInterface $output, KernelInterface $kernel, $namespace, $bundle)
     {
         $output->write('> Enabling the bundle inside AppKernel: ');
-        $manip = new KernelManipulator($kernel);
+        $kernelManipulator = new KernelManipulator($kernel);
         try {
-            $ret = $manip->addBundle($namespace.'\\'.$bundle);
+            $ret = $kernelManipulator->addBundle($namespace.'\\'.$bundle);
 
             if (!$ret) {
                 $reflected = new \ReflectionObject($kernel);
@@ -346,7 +326,7 @@ EOT
     {
         $targetRoutingPath = $this->getContainer()->getParameter('kernel.root_dir').'/config/routing.yml';
         $output->write(sprintf(
-            '> Adding a line to <info>%s</info> to import the bundle\'s routes: ',
+            '> Importing the bundle\'s routes from the <info>%s</info> file: ',
             $this->makePathRelative($targetRoutingPath)
         ));
         $routing = new RoutingManipulator($targetRoutingPath);

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -36,12 +36,12 @@ class GenerateBundleCommand extends GeneratorCommand
     {
         $this
             ->setDefinition(array(
-                new InputOption('shared', '', InputOption::VALUE_REQUIRED, 'Are you planning on using/sharing this bundle across multiple applications?'),
                 new InputOption('namespace', '', InputOption::VALUE_REQUIRED, 'The namespace of the bundle to create'),
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle'),
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The optional bundle name'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
                 new InputOption('structure', '', InputOption::VALUE_NONE, 'Whether to generate the whole directory structure'),
+                new InputOption('shared', '', InputOption::VALUE_NONE, 'Are you planning on using/sharing this bundle across multiple applications?'),
             ))
             ->setDescription('Generates a bundle')
             ->setHelp(<<<EOT
@@ -113,7 +113,7 @@ EOT
         }
 
         $generator = $this->getGenerator();
-        $generator->generate($shared, $namespace, $bundle, $dir, $format, $structure);
+        $generator->generate($namespace, $bundle, $dir, $format, $structure, $shared);
 
         $output->writeln('Generating the bundle code: <info>OK</info>');
 
@@ -138,27 +138,13 @@ EOT
         $questionHelper->writeSection($output, 'Welcome to the Symfony2 bundle generator');
 
         // shared
-        $shared = null;
-        try {
-            $shared = $input->getOption('shared') ? Validators::validateShared($input->getOption('shared')) : null;
-        } catch (\Exception $error) {
-            $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
+        $shared = $input->getOption('shared');
+
+        if (!$shared && $dialog->askConfirmation($output, '<question>Are you planning on using/sharing this bundle across multiple applications [no]?</question>', false)) {
+            $shared = true;
         }
 
-        if (null === $shared) {
-            $output->writeln(array(
-                '',
-                'There are two modes for the bundle generation:',
-                '1) Creating a re-usable, 3rd party bundle.',
-                '2) Creating a bundle for your application.',
-                '',
-                'If you prefer the second option, you can omit the vendor\'s name in the next step.',
-                '',
-            ));
-
-            $shared = $dialog->askConfirmation($output, 'Are you planning on using/sharing this bundle across multiple applications [yes]?');
-            $input->setOption('shared', $shared);
-        }
+        $shared = $input->setOption('shared', $shared);
 
         // namespace
         $namespace = null;

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -137,7 +137,7 @@ EOT
          */
         $shared = $input->getOption('shared');
 
-        if (!$shared && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on sharing this bundle across multiple applications?', 'no'), false)) {
+        if ($shared === null && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on sharing this bundle across multiple applications?', 'no'), false)) {
             $shared = true;
         }
 

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -192,7 +192,7 @@ EOT
                 $namespace = $dialog->askAndValidate(
                     $output,
                     $dialog->getQuestion('Bundle name', null),
-                    function($inputNamespace) use ($shared) {
+                    function ($inputNamespace) use ($shared) {
                         return Validators::validateBundleNamespace($inputNamespace, $shared);
                     },
                     false

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -374,10 +374,8 @@ EOT
         }
 
         $shared = $input->getOption('shared');
-        // require the vendor namespace ONLY of it's not shared
-        $requireVendorNamespace = !$shared;
 
-        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), $requireVendorNamespace);
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), $shared);
         if (!$bundleName = $input->getOption('bundle-name')) {
             $bundleName = strtr($namespace, array('\\' => ''));
         }

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -94,7 +94,7 @@ EOT
 
         $shared = $input->getOption('shared');
 
-        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'));
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), $input->getOption('shared'));
         if (!$bundle = $input->getOption('bundle-name')) {
             $bundle = strtr($namespace, array('\\' => ''));
         }
@@ -149,8 +149,7 @@ EOT
         // namespace
         $namespace = null;
         try {
-            // validate the namespace option (if any) but don't require the vendor namespace
-            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace'), false) : null;
+            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace'), $input->getOption('shared')) : null;
         } catch (\Exception $error) {
             $output->writeln($questionHelper->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
         }

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -275,8 +275,13 @@ EOT
 
     protected function updateKernel(OutputInterface $output, KernelInterface $kernel, Bundle $bundle)
     {
-        $output->write('> Enabling the bundle inside AppKernel: ');
         $kernelManipulator = new KernelManipulator($kernel);
+
+        $output->write(sprintf(
+            '> Enabling the bundle inside <info>%s</info>: ',
+            $this->makePathRelative($kernelManipulator->getFilename())
+        ));
+
         try {
             $ret = $kernelManipulator->addBundle($bundle->getBundleClassName());
 

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -203,7 +203,7 @@ EOT
                 'In your code, a bundle is often referenced by its name. It can be the',
                 'concatenation of all namespace parts but it\'s really up to you to come',
                 'up with a unique name (a good practice is to start with the vendor name).',
-                'Based on the namespace, we suggest <comment>' . $bundle . '</comment>.',
+                'Based on the namespace, we suggest <comment>'.$bundle.'</comment>.',
                 '',
             ));
             $question = new Question($questionHelper->getQuestion(

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -41,7 +41,7 @@ class GenerateBundleCommand extends GeneratorCommand
                 new InputOption('namespace', '', InputOption::VALUE_REQUIRED, 'The namespace of the bundle to create'),
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle', 'src/'),
                 new InputOption('bundle-name', '', InputOption::VALUE_REQUIRED, 'The optional bundle name'),
-                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation'),
+                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
                 new InputOption('shared', '', InputOption::VALUE_NONE, 'Are you planning on sharing this bundle across multiple applications?'),
             ))
             ->setDescription('Generates a bundle')
@@ -235,8 +235,10 @@ EOT
         /*
          * format option
          */
-        // defaults to annotation in the options
-        $format = null;
+        $format = $input->getOption('format');
+        if (!$format) {
+            $format = $shared ? 'xml' : 'annotation';
+        }
         $output->writeln(array(
             '',
             'What format do you want to use for your generated configuration?',

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -137,7 +137,7 @@ EOT
          */
         $shared = $input->getOption('shared');
 
-        if ($shared === null && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on sharing this bundle across multiple applications?', 'no'), false)) {
+        if (!$shared && $dialog->askConfirmation($output, $dialog->getQuestion('Are you planning on sharing this bundle across multiple applications?', 'no'), false)) {
             $shared = true;
         }
 

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -94,7 +94,7 @@ EOT
 
         $shared = $input->getOption('shared');
 
-        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), $input->getOption('shared'));
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), $shared);
         if (!$bundle = $input->getOption('bundle-name')) {
             $bundle = strtr($namespace, array('\\' => ''));
         }
@@ -144,12 +144,12 @@ EOT
             $shared = true;
         }
 
-        $shared = $input->setOption('shared', $shared);
+        $input->setOption('shared', $shared);
 
         // namespace
         $namespace = null;
         try {
-            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace'), $input->getOption('shared')) : null;
+            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace'), $shared) : null;
         } catch (\Exception $error) {
             $output->writeln($questionHelper->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
         }

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -139,10 +139,11 @@ EOT
             '',
         ));
 
+        $askForBundleName = true;
         if ($shared) {
             // a shared bundle, so it should probably have a vendor namespace
             $output->writeln(array(
-                'Each bundle is hosted under a namespace (like <comment>Acme/Bundle/BlogBundle</comment>).',
+                'Each bundle is hosted under a namespace (like <comment>Acme/BlogBundle</comment>).',
                 'The namespace should begin with a "vendor" name like your company name, your',
                 'project name, or your client name, followed by one or more optional category',
                 'sub-namespaces, and it should end with the bundle name itself',
@@ -182,6 +183,7 @@ EOT
                 // this is a bundle name (FooBundle) not a namespace (Acme\FooBundle)
                 // so this is the bundle name (and it is also the namespace)
                 $input->setOption('bundle-name', $namespace);
+                $askForBundleName = false;
             }
         }
         $input->setOption('namespace', $namespace);
@@ -189,29 +191,31 @@ EOT
         /*
          * bundle-name option
          */
-        $bundle = $input->getOption('bundle-name');
-        // no bundle yet? Get a default from the namespace
-        if (!$bundle) {
-            $bundle = strtr($namespace, array('\\Bundle\\' => '', '\\' => ''));
-        }
+        if ($askForBundleName) {
+            $bundle = $input->getOption('bundle-name');
+            // no bundle yet? Get a default from the namespace
+            if (!$bundle) {
+                $bundle = strtr($namespace, array('\\Bundle\\' => '', '\\' => ''));
+            }
 
-        $output->writeln(array(
-            '',
-            'In your code, a bundle is often referenced by its name. It can be the',
-            'concatenation of all namespace parts but it\'s really up to you to come',
-            'up with a unique name (a good practice is to start with the vendor name).',
-            'Based on the namespace, we suggest <comment>'.$bundle.'</comment>.',
-            '',
-        ));
-        $question = new Question($questionHelper->getQuestion(
-            'Bundle name',
-            $bundle
-        ), $bundle);
-        $question->setValidator(
-             array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleName')
-        );
-        $bundle = $questionHelper->ask($input, $output, $question);
-        $input->setOption('bundle-name', $bundle);
+            $output->writeln(array(
+                '',
+                'In your code, a bundle is often referenced by its name. It can be the',
+                'concatenation of all namespace parts but it\'s really up to you to come',
+                'up with a unique name (a good practice is to start with the vendor name).',
+                'Based on the namespace, we suggest <comment>' . $bundle . '</comment>.',
+                '',
+            ));
+            $question = new Question($questionHelper->getQuestion(
+                'Bundle name',
+                $bundle
+            ), $bundle);
+            $question->setValidator(
+                array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleName')
+            );
+            $bundle = $questionHelper->ask($input, $output, $question);
+            $input->setOption('bundle-name', $bundle);
+        }
 
         /*
          * dir option

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -179,7 +179,7 @@ EOT
             });
             $namespace = $questionHelper->ask($input, $output, $question);
 
-            if (strpos($namespace, '//') === false) {
+            if (strpos($namespace, '\\') === false) {
                 // this is a bundle name (FooBundle) not a namespace (Acme\FooBundle)
                 // so this is the bundle name (and it is also the namespace)
                 $input->setOption('bundle-name', $namespace);

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -145,7 +145,7 @@ EOT
             $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
         }
 
-        if(null === $shared) {
+        if (null === $shared) {
             $output->writeln(array(
                 '',
                 'There are two modes for the bundle generation:',
@@ -159,7 +159,6 @@ EOT
             $shared = $dialog->askConfirmation($output, 'Are you planning on using/sharing this bundle across multiple applications [yes]?');
             $input->setOption('shared', $shared);
         }
-
 
         // namespace
         $namespace = null;

--- a/Command/Helper/QuestionHelper.php
+++ b/Command/Helper/QuestionHelper.php
@@ -25,7 +25,7 @@ class QuestionHelper extends BaseQuestionHelper
     public function writeGeneratorSummary(OutputInterface $output, $errors)
     {
         if (!$errors) {
-            $this->writeSection($output, 'Everything worked! Now get to work :).');
+            $this->writeSection($output, 'Everything is OK! Now get to work :).');
         } else {
             $this->writeSection($output, array(
                 'The command was not able to configure everything automatically.',

--- a/Command/Helper/QuestionHelper.php
+++ b/Command/Helper/QuestionHelper.php
@@ -25,11 +25,11 @@ class QuestionHelper extends BaseQuestionHelper
     public function writeGeneratorSummary(OutputInterface $output, $errors)
     {
         if (!$errors) {
-            $this->writeSection($output, 'You can now start using the generated code!');
+            $this->writeSection($output, 'Everything worked! Now get to work :).');
         } else {
             $this->writeSection($output, array(
                 'The command was not able to configure everything automatically.',
-                'You must do the following changes manually.',
+                'You\'ll need to make the following changes manually.',
             ), 'error');
 
             $output->writeln($errors);
@@ -43,7 +43,7 @@ class QuestionHelper extends BaseQuestionHelper
                 $output->writeln('<fg=red>FAILED</>');
                 $errors = array_merge($errors, $err);
             } else {
-                $output->writeln('<info>OK</info>');
+                $output->writeln('<comment>OK!</comment>');
             }
         };
 

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -101,6 +101,11 @@ class Validators
 
         $format = strtolower($format);
 
+        // in case they typed "yaml", but ok with that
+        if ($format == 'yaml') {
+            $format = 'yml';
+        }
+
         if (!in_array($format, array('php', 'xml', 'yml', 'annotation'))) {
             throw new \RuntimeException(sprintf('Format "%s" is not supported.', $format));
         }

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -105,17 +105,6 @@ class Validators
         return $entity;
     }
 
-    public static function validateShared($shared)
-    {
-        $shared = strtolower($shared);
-
-        if (!in_array($shared, array('yes', 'y', 'no', 'n'))) {
-            throw new \RuntimeException(sprintf('You should respond yes or no.', $shared));
-        }
-
-        return $shared;
-    }
-
     public static function getReservedWords()
     {
         return array(

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -18,7 +18,7 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
  */
 class Validators
 {
-    public static function validateBundleNamespace($namespace, $shared=false)
+    public static function validateBundleNamespace($namespace, $shared = false)
     {
         if (!preg_match('/Bundle$/', $namespace)) {
             throw new \InvalidArgumentException('The namespace must end with Bundle.');

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -21,13 +21,14 @@ class Validators
     /**
      * Validates that the given namespace (e.g. Acme\FooBundle) is a valid format
      *
-     * If $shared is true, then we require you to have a vendor namespace (e.g. Acme).
+     * If $requireVendorNamespace is true, then we require you to have a vendor
+     * namespace (e.g. Acme).
      *
      * @param $namespace
-     * @param bool $shared
+     * @param bool $requireVendorNamespace
      * @return string
      */
-    public static function validateBundleNamespace($namespace, $shared = false)
+    public static function validateBundleNamespace($namespace, $requireVendorNamespace = true)
     {
         if (!preg_match('/Bundle$/', $namespace)) {
             throw new \InvalidArgumentException('The namespace must end with Bundle.');
@@ -47,7 +48,7 @@ class Validators
         }
 
         // validate that the namespace is at least one level deep
-        if ($shared && false === strpos($namespace, '\\')) {
+        if ($requireVendorNamespace && false === strpos($namespace, '\\')) {
             $msg = array();
             $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
             $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';
@@ -85,12 +86,6 @@ class Validators
         }
 
         return $controller;
-    }
-
-    public static function validateTargetDir($dir, $bundle, $namespace)
-    {
-        // add trailing / if necessary
-        return '/' === substr($dir, -1, 1) ? $dir : $dir.'/';
     }
 
     public static function validateFormat($format)

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -18,7 +18,7 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
  */
 class Validators
 {
-    public static function validateBundleNamespace($namespace, $requireVendorNamespace = true)
+    public static function validateBundleNamespace($namespace, $shared=false)
     {
         if (!preg_match('/Bundle$/', $namespace)) {
             throw new \InvalidArgumentException('The namespace must end with Bundle.');
@@ -38,8 +38,7 @@ class Validators
         }
 
         // validate that the namespace is at least one level deep
-        if ($requireVendorNamespace && false === strpos($namespace, '\\')) {
-            // language is (almost) duplicated in GenerateBundleCommand
+        if (false === strpos($namespace, '\\') && $shared) {
             $msg = array();
             $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
             $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -61,7 +61,7 @@ class Validators
     public static function validateBundleName($bundle)
     {
         if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $bundle)) {
-            throw new \InvalidArgumentException('The bundle name contains invalid characters.');
+            throw new \InvalidArgumentException(sprintf('The bundle name %s contains invalid characters.', $bundle));
         }
 
         if (!preg_match('/Bundle$/', $bundle)) {

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -95,6 +95,10 @@ class Validators
 
     public static function validateFormat($format)
     {
+        if (!$format) {
+            throw new \RuntimeException('Please enter a configuration format.');
+        }
+
         $format = strtolower($format);
 
         if (!in_array($format, array('php', 'xml', 'yml', 'annotation'))) {

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -18,6 +18,15 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
  */
 class Validators
 {
+    /**
+     * Validates that the given namespace (e.g. Acme\FooBundle) is a valid format
+     *
+     * If $shared is true, then we require you to have a vendor namespace (e.g. Acme).
+     *
+     * @param $namespace
+     * @param bool $shared
+     * @return string
+     */
     public static function validateBundleNamespace($namespace, $shared = false)
     {
         if (!preg_match('/Bundle$/', $namespace)) {
@@ -38,7 +47,7 @@ class Validators
         }
 
         // validate that the namespace is at least one level deep
-        if (false === strpos($namespace, '\\') && $shared) {
+        if ($shared && false === strpos($namespace, '\\')) {
             $msg = array();
             $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
             $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -105,6 +105,17 @@ class Validators
         return $entity;
     }
 
+    public static function validateShared($shared)
+    {
+        $shared = strtolower($shared);
+
+        if (!in_array($shared, array('yes', 'y', 'no', 'n'))) {
+            throw new \RuntimeException(sprintf('You should respond yes or no.', $shared));
+        }
+
+        return $shared;
+    }
+
     public static function getReservedWords()
     {
         return array(

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -46,7 +46,6 @@ class BundleGenerator extends Generator
 
         $basename = substr($bundle, 0, -6);
         $parameters = array(
-            'shared'    => $shared,
             'namespace' => $namespace,
             'bundle'    => $bundle,
             'format'    => $format,

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -28,7 +28,7 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generate($shared, $namespace, $bundle, $dir, $format, $structure)
+    public function generate($namespace, $bundle, $dir, $format, $structure, $shared)
     {
         $dir .= '/'.strtr($namespace, '\\', '/');
         if (file_exists($dir)) {

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -75,7 +75,7 @@ class BundleGenerator extends Generator
 
     public function getTargetBundleDirectory($dir, $namespace)
     {
-        return $dir . trim('/'.strtr($namespace, '\\', '/'), '/');
+        return $dir.trim('/'.strtr($namespace, '\\', '/'), '/');
     }
 
     /**

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -28,7 +28,7 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generate($namespace, $bundle, $dir, $format, $structure)
+    public function generate($shared, $namespace, $bundle, $dir, $format, $structure)
     {
         $dir .= '/'.strtr($namespace, '\\', '/');
         if (file_exists($dir)) {
@@ -46,6 +46,7 @@ class BundleGenerator extends Generator
 
         $basename = substr($bundle, 0, -6);
         $parameters = array(
+            'shared'    => $shared,
             'namespace' => $namespace,
             'bundle'    => $bundle,
             'format'    => $format,
@@ -54,8 +55,10 @@ class BundleGenerator extends Generator
         );
 
         $this->renderFile('bundle/Bundle.php.twig', $dir.'/'.$bundle.'.php', $parameters);
-        $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$basename.'Extension.php', $parameters);
-        $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
+        if ($shared) {
+            $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$basename.'Extension.php', $parameters);
+            $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
+        }
         $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/DefaultController.php', $parameters);
         $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
         $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -28,7 +28,7 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generate($namespace, $bundle, $dir, $format, $structure, $shared)
+    public function generate($namespace, $bundle, $dir, $format, $structure, $shared = false)
     {
         $dir .= '/'.strtr($namespace, '\\', '/');
         if (file_exists($dir)) {

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -75,7 +75,7 @@ class BundleGenerator extends Generator
 
     public function getTargetBundleDirectory($dir, $namespace)
     {
-        return $dir.trim('/'.strtr($namespace, '\\', '/'), '/');
+        return $dir.'/'.trim(strtr($namespace, '\\', '/'), '/');
     }
 
     /**

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -11,8 +11,8 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Generates a bundle.
@@ -28,9 +28,10 @@ class BundleGenerator extends Generator
         $this->filesystem = $filesystem;
     }
 
-    public function generateBundle($namespace, $bundle, $dir, $format, $shared)
+    public function generateBundle(Bundle $bundle)
     {
-        $dir = $this->getTargetBundleDirectory($dir, $namespace);
+        $dir = $bundle->getTargetDirectory();
+
         if (file_exists($dir)) {
             if (!is_dir($dir)) {
                 throw new \RuntimeException(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($dir)));
@@ -44,37 +45,35 @@ class BundleGenerator extends Generator
             }
         }
 
-        $basename = substr($bundle, 0, -6);
         $parameters = array(
-            'namespace' => $namespace,
-            'bundle'    => $bundle,
-            'format'    => $format,
-            'bundle_basename' => $basename,
-            'extension_alias' => Container::underscore($basename),
+            'namespace' => $bundle->getNamespace(),
+            'bundle'    => $bundle->getName(),
+            'format'    => $bundle->getConfigurationFormat(),
+            'bundle_basename' => $bundle->getBasename(),
+            'extension_alias' => $bundle->getExtensionAlias(),
         );
 
-        $this->renderFile('bundle/Bundle.php.twig', $dir.'/'.$bundle.'.php', $parameters);
-        if ($shared) {
-            $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$basename.'Extension.php', $parameters);
+        $this->renderFile('bundle/Bundle.php.twig', $dir.'/'.$bundle->getName().'.php', $parameters);
+        if ($bundle->shouldGenerateDependencyInjectionDirectory()) {
+            $this->renderFile('bundle/Extension.php.twig', $dir.'/DependencyInjection/'.$bundle->getBasename().'Extension.php', $parameters);
             $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
         }
         $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/DefaultController.php', $parameters);
         $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
         $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);
 
-        if ('yml' === $format || 'annotation' === $format) {
-            $this->renderFile('bundle/services.yml.twig', $dir.'/Resources/config/services.yml', $parameters);
-        } else {
-            $this->renderFile('bundle/services.'.$format.'.twig', $dir.'/Resources/config/services.'.$format, $parameters);
-        }
+        // render the services.yml/xml file
+        $servicesFilename = $bundle->getServicesConfigurationFilename();
+        $this->renderFile(
+            sprintf('bundle/%s.twig', $servicesFilename),
+            $dir.'/Resources/config/'.$servicesFilename, $parameters
+        );
 
-        if ('annotation' != $format) {
-            $this->renderFile('bundle/routing.'.$format.'.twig', $dir.'/Resources/config/routing.'.$format, $parameters);
+        if ($routingFilename = $bundle->getRoutingConfigurationFilename()) {
+            $this->renderFile(
+                sprintf('bundle/%s.twig', $routingFilename),
+                $dir.'/Resources/config/'.$routingFilename, $parameters
+            );
         }
-    }
-
-    public function getTargetBundleDirectory($dir, $namespace)
-    {
-        return $dir.'/'.trim(strtr($namespace, '\\', '/'), '/');
     }
 }

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -77,35 +77,4 @@ class BundleGenerator extends Generator
     {
         return $dir.'/'.trim(strtr($namespace, '\\', '/'), '/');
     }
-
-    /**
-     * This method is unused, but kept only for backwards compatibility.
-     *
-     * @deprecated
-     */
-    public function generate($namespace, $bundle, $dir, $format, $structure)
-    {
-        $this->generateBundle($namespace, $bundle, $dir, $format, false);
-
-        if ($structure) {
-            $basename = substr($bundle, 0, -6);
-
-            $parameters = array(
-                'namespace' => $namespace,
-                'bundle'    => $bundle,
-                'format'    => $format,
-                'bundle_basename' => $basename,
-                'extension_alias' => Container::underscore($basename),
-            );
-
-            $this->renderFile('bundle/messages.fr.xlf', $dir.'/Resources/translations/messages.fr.xlf', $parameters);
-
-            $this->filesystem->mkdir($dir.'/Resources/doc');
-            $this->filesystem->touch($dir.'/Resources/doc/index.rst');
-            $this->filesystem->mkdir($dir.'/Resources/translations');
-            $this->filesystem->mkdir($dir.'/Resources/public/css');
-            $this->filesystem->mkdir($dir.'/Resources/public/images');
-            $this->filesystem->mkdir($dir.'/Resources/public/js');
-        }
-    }
 }

--- a/Manipulator/ConfigurationManipulator.php
+++ b/Manipulator/ConfigurationManipulator.php
@@ -84,7 +84,7 @@ class ConfigurationManipulator extends Manipulator
     public function getImportCode(Bundle $bundle)
     {
         return sprintf(<<<EOF
-            - { resource: "@%s/Resources/config/%s" }
+    - { resource: "@%s/Resources/config/%s" }
 EOF
         ,
             $bundle->getName(),

--- a/Manipulator/ConfigurationManipulator.php
+++ b/Manipulator/ConfigurationManipulator.php
@@ -11,7 +11,6 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Manipulator;
 
-use Symfony\Component\DependencyInjection\Container;
 use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 use Symfony\Component\Yaml\Yaml;
 
@@ -74,7 +73,7 @@ class ConfigurationManipulator extends Manipulator
         // find the line break after the last import
         $targetLinebreakPosition = strpos($currentContents, "\n", $lastImportPosition);
 
-        $newContents = substr($currentContents, 0, $targetLinebreakPosition) . "\n" . $code . substr($currentContents, $targetLinebreakPosition);
+        $newContents = substr($currentContents, 0, $targetLinebreakPosition)."\n".$code.substr($currentContents, $targetLinebreakPosition);
 
         if (false === file_put_contents($this->file, $newContents)) {
             throw new \RuntimeException(sprintf('Could not write file %s ', $this->file));

--- a/Manipulator/ConfigurationManipulator.php
+++ b/Manipulator/ConfigurationManipulator.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Manipulator;
+
+use Symfony\Component\DependencyInjection\Container;
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Changes the PHP code of a YAML services configuration file.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Ryan Weaver <weaverryan@gmail.com>
+ */
+class ConfigurationManipulator extends Manipulator
+{
+    private $file;
+
+    /**
+     * Constructor.
+     *
+     * @param string $file The YAML configuration file path
+     */
+    public function __construct($file)
+    {
+        $this->file = $file;
+    }
+
+    /**
+     * Adds a configuration resource at the top of the existing ones.
+     *
+     * @param Bundle $bundle
+     *
+     * @throws \RuntimeException If this process fails for any reason
+     */
+    public function addResource(Bundle $bundle)
+    {
+        // if the config.yml file doesn't exist, don't even try.
+        if (!file_exists($this->file)) {
+            throw new \RuntimeException(sprintf('The target config file %s does not exist', $this->file));
+        }
+
+        $code = $this->getImportCode($bundle);
+
+        $currentContents = file_get_contents($this->file);
+        // Don't add same bundle twice
+        if (false !== strpos($currentContents, $code)) {
+            throw new \RuntimeException(sprintf(
+                'The %s configuration file from %s is already imported',
+                $bundle->getServicesConfigurationFilename(),
+                $bundle->getName()
+            ));
+        }
+
+        // find the "imports" line and add this at the end of that list
+        $lastImportedPath = $this->findLastImportedPath($currentContents);
+        if (!$lastImportedPath) {
+            throw new \RuntimeException(sprintf('Could not find the imports key in %s', $this->file));
+        }
+
+        // find imports:
+        $importsPosition = strpos($currentContents, 'imports:');
+        // find the last import
+        $lastImportPosition = strpos($currentContents, $lastImportedPath, $importsPosition);
+        // find the line break after the last import
+        $targetLinebreakPosition = strpos($currentContents, "\n", $lastImportPosition);
+
+        $newContents = substr($currentContents, 0, $targetLinebreakPosition) . "\n" . $code . substr($currentContents, $targetLinebreakPosition);
+
+        if (false === file_put_contents($this->file, $newContents)) {
+            throw new \RuntimeException(sprintf('Could not write file %s ', $this->file));
+        }
+    }
+
+    public function getImportCode(Bundle $bundle)
+    {
+        return sprintf(<<<EOF
+            - { resource: "@%s/Resources/config/%s" }
+EOF
+        ,
+            $bundle->getName(),
+            $bundle->getServicesConfigurationFilename()
+        );
+    }
+
+    /**
+     * Finds the last imported resource path in the YAML file
+     *
+     * @param $yamlContents
+     * @return bool|string
+     */
+    private function findLastImportedPath($yamlContents)
+    {
+        $data = Yaml::parse($yamlContents);
+        if (!isset($data['imports'])) {
+            return false;
+        }
+
+        // find the last imports entry
+        $lastImport = end($data['imports']);
+        if (!isset($lastImport['resource'])) {
+            return false;
+        }
+
+        return $lastImport['resource'];
+    }
+}

--- a/Manipulator/KernelManipulator.php
+++ b/Manipulator/KernelManipulator.php
@@ -45,11 +45,11 @@ class KernelManipulator extends Manipulator
      */
     public function addBundle($bundle)
     {
-        if (!$this->reflected->getFilename()) {
+        if (!$this->getFilename()) {
             return false;
         }
 
-        $src = file($this->reflected->getFilename());
+        $src = file($this->getFilename());
         $method = $this->reflected->getMethod('registerBundles');
         $lines = array_slice($src, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1);
 
@@ -96,10 +96,16 @@ class KernelManipulator extends Manipulator
                     array_slice($src, $this->line - 1)
                 );
 
-                file_put_contents($this->reflected->getFilename(), implode('', $lines));
+                file_put_contents($this->getFilename(), implode('', $lines));
 
                 return true;
             }
         }
     }
+
+    public function getFilename()
+    {
+        return $this->reflected->getFileName();
+    }
+
 }

--- a/Manipulator/KernelManipulator.php
+++ b/Manipulator/KernelManipulator.php
@@ -107,5 +107,4 @@ class KernelManipulator extends Manipulator
     {
         return $this->reflected->getFileName();
     }
-
 }

--- a/Model/Bundle.php
+++ b/Model/Bundle.php
@@ -55,7 +55,7 @@ class Bundle
      */
     public function getTargetDirectory()
     {
-        return $this->targetDirectory.'/'.trim(strtr($this->namespace, '\\', '/'), '/');
+        return rtrim($this->targetDirectory, '/').'/'.trim(strtr($this->namespace, '\\', '/'), '/');
     }
 
     /**

--- a/Model/Bundle.php
+++ b/Model/Bundle.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Sensio\Bundle\GeneratorBundle\Model;
+
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * Represents a bundle being built
+ */
+class Bundle
+{
+    private $namespace;
+
+    private $name;
+
+    private $targetDirectory;
+
+    private $configurationFormat;
+
+    private $isShared;
+
+    public function __construct($namespace, $name, $targetDirectory, $configurationFormat, $isShared)
+    {
+        $this->namespace = $namespace;
+        $this->name = $name;
+        $this->targetDirectory = $targetDirectory;
+        $this->configurationFormat = $configurationFormat;
+        $this->isShared = $isShared;
+    }
+
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getConfigurationFormat()
+    {
+        return $this->configurationFormat;
+    }
+
+    public function isShared()
+    {
+        return $this->isShared;
+    }
+
+    /**
+     * Returns the directory where the bundle will be generated
+     *
+     * @return string
+     */
+    public function getTargetDirectory()
+    {
+        return $this->targetDirectory.'/'.trim(strtr($this->namespace, '\\', '/'), '/');
+    }
+
+    /**
+     * Returns the name of the bundle without the Bundle suffix
+     *
+     * @return string
+     */
+    public function getBasename()
+    {
+        return substr($this->name, 0, -6);
+    }
+
+    /**
+     * Returns the dependency injection extension alias for this bundle
+     *
+     * @return string
+     */
+    public function getExtensionAlias()
+    {
+        return Container::underscore($this->getBasename());
+    }
+
+    /**
+     * Should a DependencyInjection directory be generated for this bundle?
+     *
+     * @return bool
+     */
+    public function shouldGenerateDependencyInjectionDirectory()
+    {
+        return $this->isShared;
+    }
+
+    /**
+     * What is the filename for the services.yml/xml file?
+     *
+     * @return string
+     */
+    public function getServicesConfigurationFilename()
+    {
+        if ('yml' === $this->getConfigurationFormat() || 'annotation' === $this->configurationFormat) {
+            return 'services.yml';
+        } else {
+            return 'services.'.$this->getConfigurationFormat();
+        }
+    }
+
+    /**
+     * What is the filename for the routing.yml/xml file?
+     *
+     * If false, no routing file will be generated
+     *
+     * @return string|bool
+     */
+    public function getRoutingConfigurationFilename()
+    {
+        if ($this->getConfigurationFormat() == 'annotation') {
+            return false;
+        }
+
+        return 'routing.'.$this->getConfigurationFormat();
+    }
+
+    /**
+     * Returns the class name of the Bundle class
+     *
+     * @return string
+     */
+    public function getBundleClassName()
+    {
+        return $this->namespace.'\\'.$this->name;
+    }
+}

--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -25,8 +25,7 @@ forget to pass all needed options:
 Available Options
 -----------------
 
-* ``--shared``: If present, create a DependencyInjection directory.
-  Not recommended if you no planning share the bundle.
+* ``--shared``: Not recommended if you don't plan to share the bundle with other projects.
 
 * ``--namespace``: The namespace of the bundle to create. The namespace should
   begin with a "vendor" name like your company name, your project name, or

--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -64,10 +64,3 @@ Available Options
 
         php app/console generate:bundle --format=annotation
 
-* ``--structure``: If present, generates a
-  complete default directory structure including empty public folders for
-  documentation, web assets and translations dictionaries:
-
-    .. code-block:: bash
-
-        php app/console generate:bundle --structure

--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -25,6 +25,9 @@ forget to pass all needed options:
 Available Options
 -----------------
 
+* ``--shared``: If present, create a DependencyInjection directory.
+  Not recommended if you no planning share the bundle.
+
 * ``--namespace``: The namespace of the bundle to create. The namespace should
   begin with a "vendor" name like your company name, your project name, or
   your client name, followed by one or more optional category sub-namespaces,

--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -25,7 +25,10 @@ forget to pass all needed options:
 Available Options
 -----------------
 
-* ``--shared``: Not recommended if you don't plan to share the bundle with other projects.
+* ``--shared``: set this option if you are creating a bundle that will be shared
+  across several of your applications or if you are developing a third-party
+  bundle. Don't set this option if you are developing a bundle that will be
+  used solely in your application (e.g. ``AppBundle``).
 
 * ``--namespace``: The namespace of the bundle to create. The namespace should
   begin with a "vendor" name like your company name, your project name, or

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -39,9 +39,21 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'), "y\nFoo/BarBundle\n", array(true,'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array(), "y\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "y\nFoo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(
+                array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'),
+                "y\nFoo/BarBundle\n",
+                array(true,'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)
+            ),
+            array(
+                array(),
+                "y\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn",
+                array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)
+            ),
+            array(
+                array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true),
+                "y\nFoo/BarBundle\n",
+                array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+            ),
         );
     }
 
@@ -68,8 +80,14 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(
+                array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle'),
+                array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)
+            ),
+            array(
+                array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true),
+                array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+            ),
         );
     }
 

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -27,7 +27,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($shared, $namespace, $bundle, $dir, $format, $structure)
+            ->with($namespace, $bundle, $dir, $format, $structure, $shared)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -41,7 +41,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return array(
             array(array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'), "y\nFoo/BarBundle\n", array(true,'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
             array(array(), "y\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "y\nFoo/BarBundle\n", array(true,'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "y\nFoo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 
@@ -56,7 +56,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($shared, $namespace, $bundle, $dir, $format, $structure)
+            ->with($namespace, $bundle, $dir, $format, $structure, $shared)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, ''));

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -43,8 +43,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return array(
             array(
                 array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'),
-                // namespace
-                "Foo/BarBundle\n",
+                // shared, namespace, bundle name, directory, format
+                "\nFoo/BarBundle\n\n\n\n",
                 array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true),
             ),
             array(
@@ -55,14 +55,14 @@ class GenerateBundleCommandTest extends GenerateCommandTest
             ),
             array(
                 array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle'),
-                // namespace
-                "Foo/BarBundle\n",
+                // shared, namespace, bundle name, directory, format
+                "\nFoo/BarBundle\n\n\n\n",
                 array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true),
             ),
             array(
                 array(),
-                // shared, bundle name, directory, format
-                "n\nBazBundle\nsrc\nannotation",
+                // shared, namespace, bundle name, directory, format
+                "n\nBazBundle\n\nsrc\nannotation",
                 array('BazBundle', 'BazBundle', 'src/', 'annotation', false),
             ),
         );

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -39,9 +39,9 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array(), "yes\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'), "y\nFoo/BarBundle\n", array(true,'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
+            array(array(), "y\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
+            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "y\nFoo/BarBundle\n", array(true,'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -39,9 +39,9 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array(), "Foo/BarBundle\nBarBundle\nfoo\nyml\nn", array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
+            array(array(), "Foo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
+            array(array('--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 
@@ -68,8 +68,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
+            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -21,13 +21,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testInteractiveCommand($options, $input, $expected)
     {
-        list($shared, $namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($namespace, $bundle, $dir, $format, $shared) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
-            ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure, $shared)
+            ->method('generateBundle')
+            ->with($namespace, $bundle, $dir, $format, $shared)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -41,18 +41,27 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return array(
             array(
                 array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'),
-                "y\nFoo/BarBundle\n",
-                array(true,'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)
+                // namespace
+                "Foo/BarBundle\n",
+                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true)
             ),
             array(
                 array(),
-                "y\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn",
-                array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)
+                // shared, namespace, bundle name, directory, format
+                "y\nFoo/BarBundle\nBarBundle\nfoo\nyml",
+                array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', true)
             ),
             array(
-                array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true),
-                "y\nFoo/BarBundle\n",
-                array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+                array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle'),
+                // namespace
+                "Foo/BarBundle\n",
+                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+            ),
+            array(
+                array(),
+                // shared, bundle name, directory, format
+                "n\nBazBundle\nsrc\nannotation",
+                array('BazBundle', 'BazBundle', 'src/', 'annotation', false)
             ),
         );
     }
@@ -62,13 +71,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testNonInteractiveCommand($options, $expected)
     {
-        list($shared, $namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($namespace, $bundle, $dir, $format, $shared) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
-            ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure, $shared)
+            ->method('generateBundle')
+            ->with($namespace, $bundle, $dir, $format, $shared)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, ''));
@@ -82,11 +91,15 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return array(
             array(
                 array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle'),
-                array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)
+                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true)
             ),
             array(
-                array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true),
-                array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+                array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle'),
+                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+            ),
+            array(
+                array('--dir' => $tmp, '--namespace' => 'BazBundle', '--format' => 'yml', '--bundle-name' => 'BazBundle'),
+                array('BazBundle', 'BazBundle', $tmp.'/', 'yml', false)
             ),
         );
     }
@@ -112,7 +125,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return $this
             ->getMockBuilder('Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator')
             ->disableOriginalConstructor()
-            ->setMethods(array('generate'))
+            ->setMethods(array('generateBundle'))
             ->getMock()
         ;
     }

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -43,25 +43,25 @@ class GenerateBundleCommandTest extends GenerateCommandTest
                 array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'),
                 // namespace
                 "Foo/BarBundle\n",
-                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true)
+                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true),
             ),
             array(
                 array(),
                 // shared, namespace, bundle name, directory, format
                 "y\nFoo/BarBundle\nBarBundle\nfoo\nyml",
-                array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', true)
+                array('Foo\BarBundle', 'BarBundle', 'foo/', 'yml', true),
             ),
             array(
                 array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle'),
                 // namespace
                 "Foo/BarBundle\n",
-                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true),
             ),
             array(
                 array(),
                 // shared, bundle name, directory, format
                 "n\nBazBundle\nsrc\nannotation",
-                array('BazBundle', 'BazBundle', 'src/', 'annotation', false)
+                array('BazBundle', 'BazBundle', 'src/', 'annotation', false),
             ),
         );
     }
@@ -91,15 +91,15 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         return array(
             array(
                 array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle'),
-                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true)
+                array('Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', true),
             ),
             array(
                 array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle'),
-                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)
+                array('Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true),
             ),
             array(
                 array('--dir' => $tmp, '--namespace' => 'BazBundle', '--format' => 'yml', '--bundle-name' => 'BazBundle'),
-                array('BazBundle', 'BazBundle', $tmp.'/', 'yml', false)
+                array('BazBundle', 'BazBundle', $tmp.'/', 'yml', false),
             ),
         );
     }

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -21,13 +21,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testInteractiveCommand($options, $input, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($shared, $namespace, $bundle, $dir, $format, $structure) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure)
+            ->with($shared, $namespace, $bundle, $dir, $format, $structure)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -50,13 +50,13 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testNonInteractiveCommand($options, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $structure) = $expected;
+        list($shared, $namespace, $bundle, $dir, $format, $structure) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($namespace, $bundle, $dir, $format, $structure)
+            ->with($shared, $namespace, $bundle, $dir, $format, $structure)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, ''));

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -39,9 +39,9 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array(), "Foo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
-            array(array('--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'annotation'), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
+            array(array(), "yes\nFoo/BarBundle\nBarBundle\nfoo\nyml\nn", array(true, 'Foo\BarBundle', 'BarBundle', 'foo/', 'yml', false)),
+            array(array('--shared' => true, '--dir' => $tmp, '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), "Foo/BarBundle\n", array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 
@@ -68,8 +68,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $tmp = sys_get_temp_dir();
 
         return array(
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
-            array(array('--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
+            array(array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle'), array(true, 'Foo\BarBundle', 'FooBarBundle', $tmp.'/', 'annotation', false)),
+            array(array('--shared' => true, '--dir' => $tmp, '--namespace' => 'Foo/BarBundle', '--format' => 'yml', '--bundle-name' => 'BarBundle', '--structure' => true), array(true, 'Foo\BarBundle', 'BarBundle', $tmp.'/', 'yml', true)),
         );
     }
 

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Tests\Command;
 
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 use Symfony\Component\Console\Tester\CommandTester;
 use Sensio\Bundle\GeneratorBundle\Command\GenerateBundleCommand;
 
@@ -21,13 +22,14 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testInteractiveCommand($options, $input, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $shared) = $expected;
+        list($namespace, $bundleName, $dir, $format, $shared) = $expected;
+        $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generateBundle')
-            ->with($namespace, $bundle, $dir, $format, $shared)
+            ->with($bundle)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -71,13 +73,14 @@ class GenerateBundleCommandTest extends GenerateCommandTest
      */
     public function testNonInteractiveCommand($options, $expected)
     {
-        list($namespace, $bundle, $dir, $format, $shared) = $expected;
+        list($namespace, $bundleName, $dir, $format, $shared) = $expected;
+        $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generateBundle')
-            ->with($namespace, $bundle, $dir, $format, $shared)
+            ->with($bundle)
         ;
 
         $tester = new CommandTester($this->getCommand($generator, ''));

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -17,7 +17,7 @@ class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
 
         $files = array(
             'FooBarBundle.php',
@@ -49,7 +49,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateXml()
     {
-        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false, true);
 
         $files = array(
             'FooBarBundle.php',
@@ -71,7 +71,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false, false);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
@@ -86,7 +86,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
         try {
-            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -99,7 +99,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
         try {
-            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -113,7 +113,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
         try {
-            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -125,7 +125,7 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
     }
 
     protected function getGenerator()

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -17,7 +17,7 @@ class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
 
         $files = array(
             'FooBarBundle.php',
@@ -49,7 +49,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateXml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false);
+        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false);
 
         $files = array(
             'FooBarBundle.php',
@@ -71,7 +71,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
@@ -86,7 +86,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -99,7 +99,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -113,7 +113,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -125,7 +125,7 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+        $this->getGenerator()->generate(true, 'Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
     }
 
     protected function getGenerator()

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -17,7 +17,7 @@ class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
+        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
 
         $files = array(
             'FooBarBundle.php',
@@ -49,7 +49,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateXml()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', false, true);
+        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', true);
 
         $files = array(
             'FooBarBundle.php',
@@ -71,7 +71,7 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false, false);
+        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
@@ -86,7 +86,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
+            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -99,7 +99,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
+            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -113,7 +113,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
         try {
-            $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, false);
+            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -125,7 +125,7 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false, true);
+        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
     }
 
     protected function getGenerator()

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -12,12 +12,14 @@
 namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
 
 use Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator;
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 
 class BundleGeneratorTest extends GeneratorTest
 {
     public function testGenerateYaml()
     {
-        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
+        $this->getGenerator()->generateBundle($bundle);
 
         $files = array(
             'FooBarBundle.php',
@@ -49,7 +51,8 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateXml()
     {
-        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', true);
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', true);
+        $this->getGenerator()->generateBundle($bundle);
 
         $files = array(
             'FooBarBundle.php',
@@ -71,7 +74,8 @@ class BundleGeneratorTest extends GeneratorTest
 
     public function testGenerateAnnotation()
     {
-        $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'annotation', false);
+        $this->getGenerator()->generateBundle($bundle);
 
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.yml'));
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
@@ -85,8 +89,9 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->mkdir($this->tmpDir.'/Foo');
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle');
 
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
         try {
-            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generateBundle($bundle);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->assertEquals(sprintf('Unable to generate the bundle as the target directory "%s" exists but is a file.', realpath($this->tmpDir.'/Foo/BarBundle')), $e->getMessage());
@@ -98,8 +103,9 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
         $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0444);
 
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
         try {
-            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generateBundle($bundle);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -112,8 +118,9 @@ class BundleGeneratorTest extends GeneratorTest
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
         $this->filesystem->touch($this->tmpDir.'/Foo/BarBundle/somefile');
 
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
         try {
-            $this->getGenerator()->generateBundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', false);
+            $this->getGenerator()->generateBundle($bundle);
             $this->fail('An exception was expected!');
         } catch (\RuntimeException $e) {
             $this->filesystem->chmod($this->tmpDir.'/Foo/BarBundle', 0777);
@@ -125,7 +132,8 @@ class BundleGeneratorTest extends GeneratorTest
     {
         $this->filesystem->mkdir($this->tmpDir.'/Foo/BarBundle');
 
-        $this->getGenerator()->generate('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'yml', true);
+        $this->getGenerator()->generateBundle($bundle);
     }
 
     protected function getGenerator()

--- a/Tests/Manipulator/ConfigurationManipulatorTest.php
+++ b/Tests/Manipulator/ConfigurationManipulatorTest.php
@@ -11,7 +11,6 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
 
-use Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator;
 use Sensio\Bundle\GeneratorBundle\Manipulator\ConfigurationManipulator;
 use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 use Symfony\Component\Filesystem\Filesystem;
@@ -23,7 +22,7 @@ class ConfigurationManipulatorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->tmpDir = sys_get_temp_dir() . '/sf2';
+        $this->tmpDir = sys_get_temp_dir().'/sf2';
         $this->filesystem = new Filesystem();
         $this->filesystem->remove($this->tmpDir);
         $this->filesystem->mkdir($this->tmpDir);

--- a/Tests/Manipulator/ConfigurationManipulatorTest.php
+++ b/Tests/Manipulator/ConfigurationManipulatorTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
+
+use Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator;
+use Sensio\Bundle\GeneratorBundle\Manipulator\ConfigurationManipulator;
+use Sensio\Bundle\GeneratorBundle\Model\Bundle;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ConfigurationManipulatorTest extends GeneratorTest
+{
+    protected $filesystem;
+    protected $tmpDir;
+
+    public function setUp()
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/sf2';
+        $this->filesystem = new Filesystem();
+        $this->filesystem->remove($this->tmpDir);
+        $this->filesystem->mkdir($this->tmpDir);
+    }
+
+    public function tearDown()
+    {
+        $this->filesystem->remove($this->tmpDir);
+    }
+
+    /**
+     * @dataProvider getAddResourcesTests
+     */
+    public function testAddResource($bundleName, $format, $startingContents, $expectedContents)
+    {
+        $bundle = new Bundle('Acme', $bundleName, 'src', $format, true);
+
+        $configurationPath = $this->tmpDir.'/config.yml';
+        file_put_contents($configurationPath, $startingContents);
+        $manipulator = new ConfigurationManipulator($configurationPath);
+
+        $manipulator->addResource($bundle);
+        $realContents = file_get_contents($configurationPath);
+        $this->assertEquals($expectedContents, $realContents);
+    }
+
+    public function getAddResourcesTests()
+    {
+        $tests = array();
+
+        // normal, .yml file
+        $tests[] = array(
+            'AppBundle',
+            'yml',
+            <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+            , <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+    - { resource: "@AppBundle/Resources/config/services.yml" }
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+        );
+
+        // normal, xml file
+        $tests[] = array(
+            'AppBundle',
+            'xml',
+            <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+            , <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+    - { resource: "@AppBundle/Resources/config/services.xml" }
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+        );
+
+        // imports further down
+        $tests[] = array(
+            'AppBundle',
+            'yml',
+            <<<EOF
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+
+twig:
+    debug:            %kernel.debug%
+    strict_variables: %kernel.debug%
+EOF
+            , <<<EOF
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+    - { resource: services.yml }
+    - { resource: "@AppBundle/Resources/config/services.yml" }
+
+twig:
+    debug:            %kernel.debug%
+    strict_variables: %kernel.debug%
+EOF
+        );
+
+        // extra line breaks in the imports list
+        $tests[] = array(
+            'AppBundle',
+            'yml',
+            <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+
+    - { resource: services.yml }
+
+
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+            , <<<EOF
+imports:
+    - { resource: security.yml }
+    - { resource: parameters.yml }
+
+    - { resource: services.yml }
+    - { resource: "@AppBundle/Resources/config/services.yml" }
+
+
+framework:
+    esi:             { enabled: true }
+    translator:      { fallback: en }
+EOF
+        );
+
+        return $tests;
+    }
+}

--- a/Tests/Manipulator/ConfigurationManipulatorTest.php
+++ b/Tests/Manipulator/ConfigurationManipulatorTest.php
@@ -16,7 +16,7 @@ use Sensio\Bundle\GeneratorBundle\Manipulator\ConfigurationManipulator;
 use Sensio\Bundle\GeneratorBundle\Model\Bundle;
 use Symfony\Component\Filesystem\Filesystem;
 
-class ConfigurationManipulatorTest extends GeneratorTest
+class ConfigurationManipulatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $filesystem;
     protected $tmpDir;


### PR DESCRIPTION
Hi guys!

If you're reading this, please try this out and offer any feedback! There are so many different cases, it will make @fabpot's life much much easier (and that's always good).

This replaces (adds to) @rafix's work on #299. The task ended up being a bit larger, because there are so many things we *could* change, and we need to communicate things well.

Fortunately, the changes here alter the generation process very little - most changes are to *how* we ask the questions. Here are the highlights:

* if a bundle is non-shared, we only ask for a bundle name, not a namespace
* removed "generate full directory structure" functionality entirely. This added only a few extra files, which I don't think add value.
* make `.yml` the service configuration format if you choose annotation format. If you're using annotation for routing, it's likely you're following the best practices are you might be surprised by XML :)
* many small output changes

BC breaks:

* `BundleGenerator::generate` is now gone
* The `structure` option was removed
* You now get `services.yml` if you choose annotation as your format

In #299, we asked the question "should a non-shared bundle have a `Resources/` directory?". I think it should. Why? I think the `AppBundle` is special - it's the one bundle that's truly coupled to your kernel (e.g. `app/` directory), which is why it's ok to store the templates in `app/`. If we also stored templates from other bundles in `app/`, it gets a crowded. If you had a `DefaultController` in 2 bundles, their templates would "want" to occupy the same space (e.g. `app/Resources/views/default/*`).  So, I think it makes sense to have only one special bundle (per kernel) that you really *couple* to the kernel. *IF* you choose to add other bundles (which you don't need to do), I think you should organize them more along the lines of traditional bundle, at least for templates.

### TODOS

* [x] Import services.xml/yml manually from config.yml for non-shared bundle
* [x] Can we break BC in the ways described above? Or do I need to re-add somethings?
* [x] Fix the GenerateBundleCommandTest
* [x] Add more cases to BundleGeneratorTest for no DI directory
* [x] Fix BundleGeneratorTest


What does everyone think? /cc @javiereguiluz 

Thanks!