### PR TITLE
generate:bundle Allowing a namespace to be used without a vendor namespace

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -90,7 +90,8 @@ EOT
             }
         }
 
-        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'));
+        // validate the namespace, but don't require a vendor namespace
+        $namespace = Validators::validateBundleNamespace($input->getOption('namespace'), false);
         if (!$bundle = $input->getOption('bundle-name')) {
             $bundle = strtr($namespace, array('\\' => ''));
         }
@@ -136,7 +137,8 @@ EOT
         // namespace
         $namespace = null;
         try {
-            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace')) : null;
+            // validate the namespace option (if any) but don't require the vendor namespace
+            $namespace = $input->getOption('namespace') ? Validators::validateBundleNamespace($input->getOption('namespace'), false) : null;
         } catch (\Exception $error) {
             $output->writeln($dialog->getHelperSet()->get('formatter')->formatBlock($error->getMessage(), 'error'));
         }
@@ -160,7 +162,41 @@ EOT
                 '',
             ));
 
-            $namespace = $dialog->askAndValidate($output, $dialog->getQuestion('Bundle namespace', $input->getOption('namespace')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateBundleNamespace'), false, $input->getOption('namespace'));
+            $acceptedNamespace = false;
+            while (!$acceptedNamespace) {
+                $namespace = $dialog->askAndValidate(
+                    $output,
+                    $dialog->getQuestion('Bundle namespace', $input->getOption('namespace')),
+                    function ($namespace) use ($dialog, $output) {
+                        // validate it, but don't require the vendor namespace
+                        return Validators::validateBundleNamespace($namespace, false);
+                    },
+                    false,
+                    $input->getOption('namespace')
+                );
+
+                // mark as accepted, unless they want to try again below
+                $acceptedNamespace = true;
+
+                // see if there is a vendor namespace. If not, this could be accidental
+                if (false === strpos($namespace, '\\')) {
+                    // language is (almost) duplicated in Validators
+                    $msg = array();
+                    $msg[] = '';
+                    $msg[] = sprintf('The namespace sometimes contain a vendor namespace (e.g. <info>VendorName/BlogBundle</info> instead of simply <info>%s</info>).', $namespace, $namespace);
+                    $msg[] = 'If you\'ve *did* type a vendor namespace, try using a forward slash <info>/</info> (<info>Acme/BlogBundle</info>)?';
+                    $msg[] = '';
+                    $output->writeln($msg);
+
+                    $acceptedNamespace = $dialog->askConfirmation(
+                        $output,
+                        $dialog->getQuestion(
+                            sprintf('Keep <comment>%s</comment> as the bundle namespace (choose no to try again)?', $namespace),
+                            'yes'
+                        )
+                    );
+                }
+            }
             $input->setOption('namespace', $namespace);
         }
 

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -18,7 +18,7 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
  */
 class Validators
 {
-    public static function validateBundleNamespace($namespace)
+    public static function validateBundleNamespace($namespace, $requireVendorNamespace = true)
     {
         if (!preg_match('/Bundle$/', $namespace)) {
             throw new \InvalidArgumentException('The namespace must end with Bundle.');
@@ -38,7 +38,8 @@ class Validators
         }
 
         // validate that the namespace is at least one level deep
-        if (false === strpos($namespace, '\\')) {
+        if ($requireVendorNamespace && false === strpos($namespace, '\\')) {
+            // language is (almost) duplicated in GenerateBundleCommand
             $msg = array();
             $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
             $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';


### PR DESCRIPTION
Hey guys!

This is a quick, BC version of #312, which has become a major update to the entire command. That's great, but it will break some BC and will need to be released as a new version.

But right now, it's still impossible to generate a bundle without a vendor namespace. That was the original issue, and the fix is very simple. This fixes that in a BC way. If you _do_ omit the vendor namespace, it even gives you a warning (in case someone accidentally says `Acme/FooBundle`, which looks like `AcmeFooBundle` to the system).

I've tested both sides of the flow and it works fine. If someone else can double-check, that'll make Fabien's merge much easier. Screenshots Below!

Thanks!

![screen shot 2014-11-25 at 5 16 28 pm](https://cloud.githubusercontent.com/assets/121003/5192677/59c114c2-74c7-11e4-9f0e-d4a36366598c.png)
![screen shot 2014-11-25 at 5 16 51 pm](https://cloud.githubusercontent.com/assets/121003/5192676/59c0e0e2-74c7-11e4-9e77-8ade8dc48ac1.png)
