### PR TITLE
Generate entity repositories in 'Repository' namespace

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Sensio\Bundle\GeneratorBundle\Generator\BundleGenerator;
 use Sensio\Bundle\GeneratorBundle\Manipulator\KernelManipulator;
 use Sensio\Bundle\GeneratorBundle\Manipulator\RoutingManipulator;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 
 /**
  * Generates bundles.
@@ -360,9 +359,10 @@ EOT
     }
 
     /**
-     * Creates the Bundle object based on the user's (non-interactive) input
+     * Creates the Bundle object based on the user's (non-interactive) input.
      *
      * @param InputInterface $input
+     *
      * @return Bundle
      */
     protected function createBundleObject(InputInterface $input)

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -401,19 +401,6 @@ EOT
         );
     }
 
-    /**
-     * Tries to make a path relative to the project, which prints nicer
-     *
-     * @param string $absolutePath
-     * @return string
-     */
-    protected function makePathRelative($absolutePath)
-    {
-        $projectRootDir = dirname($this->getContainer()->getParameter('kernel.root_dir'));
-
-        return str_replace($projectRootDir.'/', '', $absolutePath);
-    }
-
     protected function createGenerator()
     {
         return new BundleGenerator($this->getContainer()->get('filesystem'));

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -37,7 +37,6 @@ class GenerateDoctrineEntityCommand extends GenerateDoctrineCommand
             ->addOption('entity', null, InputOption::VALUE_REQUIRED, 'The entity class name to initialize (shortcut notation)')
             ->addOption('fields', null, InputOption::VALUE_REQUIRED, 'The fields to create with the new entity')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation')
-            ->addOption('with-repository', null, InputOption::VALUE_NONE, 'Whether to generate the entity repository or not')
             ->setHelp(<<<EOT
 The <info>doctrine:generate:entity</info> task generates a new Doctrine
 entity inside a bundle:
@@ -51,11 +50,6 @@ You can also optionally specify the fields you want to generate in the new
 entity:
 
 <info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post --fields="title:string(255) body:text"</info>
-
-The command can also generate the corresponding entity repository class with the
-<comment>--with-repository</comment> option:
-
-<info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post --with-repository</info>
 
 By default, the command uses annotations for the mapping information; change it
 with <comment>--format</comment>:
@@ -96,7 +90,7 @@ EOT
         $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
 
         $generator = $this->getGenerator();
-        $generator->generate($bundle, $entity, $format, array_values($fields), $input->getOption('with-repository'));
+        $generator->generate($bundle, $entity, $format, array_values($fields));
 
         $output->writeln('Generating the entity code: <info>OK</info>');
 
@@ -165,12 +159,6 @@ EOT
 
         // fields
         $input->setOption('fields', $this->addFields($input, $output, $questionHelper));
-
-        // repository?
-        $output->writeln('');
-        $question = new ConfirmationQuestion($questionHelper->getQuestion('Do you want to generate an empty repository class', $input->getOption('with-repository') ? 'yes' : 'no', '?'), $input->getOption('with-repository'));
-        $withRepository = $questionHelper->ask($input, $output, $question);
-        $input->setOption('with-repository', $withRepository);
 
         // summary
         $output->writeln(array(

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Doctrine\DBAL\Types\Type;
 
 /**

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -71,15 +71,6 @@ EOT
     {
         $questionHelper = $this->getQuestionHelper();
 
-        if ($input->isInteractive()) {
-            $question = new ConfirmationQuestion($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
-            if (!$questionHelper->ask($input, $output, $question)) {
-                $output->writeln('<error>Command aborted</error>');
-
-                return 1;
-            }
-        }
-
         $entity = Validators::validateEntityName($input->getOption('entity'));
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
         $format = Validators::validateFormat($input->getOption('format'));
@@ -173,16 +164,6 @@ EOT
 
         // fields
         $input->setOption('fields', $this->addFields($input, $output, $questionHelper));
-
-        // summary
-        $output->writeln(array(
-            '',
-            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg=white', true),
-            '',
-            sprintf("You are going to generate a \"<info>%s:%s</info>\" Doctrine2 entity", $bundle, $entity),
-            sprintf("using the \"<info>%s</info>\" format.", $format),
-            '',
-        ));
     }
 
     private function parseFields($input)

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -89,10 +89,24 @@ EOT
 
         $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
 
+        /** @var DoctrineEntityGenerator $generator */
         $generator = $this->getGenerator();
-        $generator->generate($bundle, $entity, $format, array_values($fields));
+        $generatorResult = $generator->generate($bundle, $entity, $format, array_values($fields));
 
-        $output->writeln('Generating the entity code: <info>OK</info>');
+        $output->writeln(sprintf(
+            '> Generating entity class <info>%s</info>: <comment>OK!</comment>',
+            $this->makePathRelative($generatorResult->getEntityPath())
+        ));
+        $output->writeln(sprintf(
+            '> Generating repository class <info>%s</info>: <comment>OK!</comment>',
+            $this->makePathRelative($generatorResult->getRepositoryPath())
+        ));
+        if ($generatorResult->getMappingPath()) {
+            $output->writeln(sprintf(
+                '> Generating mapping file <info>%s</info>: <comment>OK!</comment>',
+                $this->makePathRelative($generatorResult->getMappingPath())
+            ));
+        }
 
         $questionHelper->writeGeneratorSummary($output, array());
     }

--- a/Command/GeneratorCommand.php
+++ b/Command/GeneratorCommand.php
@@ -72,15 +72,16 @@ abstract class GeneratorCommand extends ContainerAwareCommand
     }
 
     /**
-     * Tries to make a path relative to the project, which prints nicer
+     * Tries to make a path relative to the project, which prints nicer.
      *
      * @param string $absolutePath
+     *
      * @return string
      */
     protected function makePathRelative($absolutePath)
     {
         $projectRootDir = dirname($this->getContainer()->getParameter('kernel.root_dir'));
 
-        return str_replace($projectRootDir.'/', '', realpath($absolutePath)?:$absolutePath);
+        return str_replace($projectRootDir.'/', '', realpath($absolutePath) ?: $absolutePath);
     }
 }

--- a/Command/GeneratorCommand.php
+++ b/Command/GeneratorCommand.php
@@ -70,4 +70,17 @@ abstract class GeneratorCommand extends ContainerAwareCommand
 
         return $question;
     }
+
+    /**
+     * Tries to make a path relative to the project, which prints nicer
+     *
+     * @param string $absolutePath
+     * @return string
+     */
+    protected function makePathRelative($absolutePath)
+    {
+        $projectRootDir = dirname($this->getContainer()->getParameter('kernel.root_dir'));
+
+        return str_replace($projectRootDir.'/', '', realpath($absolutePath)?:$absolutePath);
+    }
 }

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -36,7 +36,7 @@ class DoctrineEntityGenerator extends Generator
         $this->registry = $registry;
     }
 
-    public function generate(BundleInterface $bundle, $entity, $format, array $fields, $withRepository)
+    public function generate(BundleInterface $bundle, $entity, $format, array $fields)
     {
         // configure the bundle (needed if the bundle does not contain any Entities yet)
         $config = $this->registry->getManager(null)->getConfiguration();
@@ -52,9 +52,7 @@ class DoctrineEntityGenerator extends Generator
         }
 
         $class = new ClassMetadataInfo($entityClass);
-        if ($withRepository) {
-            $class->customRepositoryClassName = str_replace('\\Entity\\', '\\Repository\\', $entityClass).'Repository';
-        }
+        $class->customRepositoryClassName = str_replace('\\Entity\\', '\\Repository\\', $entityClass).'Repository';
         $class->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $class->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
         foreach ($fields as $field) {
@@ -88,10 +86,8 @@ class DoctrineEntityGenerator extends Generator
             file_put_contents($mappingPath, $mappingCode);
         }
 
-        if ($withRepository) {
-            $path = $bundle->getPath().str_repeat('/..', substr_count(get_class($bundle), '\\'));
-            $this->getRepositoryGenerator()->writeEntityRepositoryClass($class->customRepositoryClassName, $path);
-        }
+        $path = $bundle->getPath().str_repeat('/..', substr_count(get_class($bundle), '\\'));
+        $this->getRepositoryGenerator()->writeEntityRepositoryClass($class->customRepositoryClassName, $path);
     }
 
     public function isReservedKeyword($keyword)

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Generator;
 
+use Sensio\Bundle\GeneratorBundle\Model\EntityGeneratorResult;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Bridge\Doctrine\RegistryInterface;
@@ -36,6 +37,16 @@ class DoctrineEntityGenerator extends Generator
         $this->registry = $registry;
     }
 
+    /**
+     * @param BundleInterface $bundle
+     * @param string          $entity
+     * @param string          $format
+     * @param array           $fields
+     *
+     * @return EntityGeneratorResult
+     *
+     * @throws \Doctrine\ORM\Tools\Export\ExportException
+     */
     public function generate(BundleInterface $bundle, $entity, $format, array $fields)
     {
         // configure the bundle (needed if the bundle does not contain any Entities yet)
@@ -88,6 +99,9 @@ class DoctrineEntityGenerator extends Generator
 
         $path = $bundle->getPath().str_repeat('/..', substr_count(get_class($bundle), '\\'));
         $this->getRepositoryGenerator()->writeEntityRepositoryClass($class->customRepositoryClassName, $path);
+        $repositoryPath = $path.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $class->customRepositoryClassName).'.php';
+
+        return new EntityGeneratorResult($entityPath, $repositoryPath, $mappingPath);
     }
 
     public function isReservedKeyword($keyword)

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -53,7 +53,7 @@ class DoctrineEntityGenerator extends Generator
 
         $class = new ClassMetadataInfo($entityClass);
         if ($withRepository) {
-            $class->customRepositoryClassName = $entityClass.'Repository';
+            $class->customRepositoryClassName = str_replace('\\Entity\\', '\\Repository\\', $entityClass).'Repository';
         }
         $class->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $class->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/Model/EntityGeneratorResult.php
+++ b/Model/EntityGeneratorResult.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sensio\Bundle\GeneratorBundle\Model;
+
+class EntityGeneratorResult
+{
+    /** @var string */
+    private $entityPath;
+
+    /** @var string */
+    private $repositoryPath;
+
+    /** @var string */
+    private $mappingPath;
+
+    function __construct($entityPath, $repositoryPath, $mappingPath)
+    {
+        $this->entityPath = $entityPath;
+        $this->repositoryPath = $repositoryPath;
+        $this->mappingPath = $mappingPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEntityPath()
+    {
+        return $this->entityPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepositoryPath()
+    {
+        return $this->repositoryPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMappingPath()
+    {
+        return $this->mappingPath;
+    }
+}

--- a/Tests/Command/GenerateDoctrineEntityCommandTest.php
+++ b/Tests/Command/GenerateDoctrineEntityCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Tests\Command;
 
+use Sensio\Bundle\GeneratorBundle\Model\EntityGeneratorResult;
 use Symfony\Component\Console\Tester\CommandTester;
 use Sensio\Bundle\GeneratorBundle\Command\GenerateDoctrineEntityCommand;
 
@@ -28,6 +29,7 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
             ->expects($this->once())
             ->method('generate')
             ->with($this->getBundle(), $entity, $format, $fields)
+            ->willReturn(new EntityGeneratorResult('', '', ''))
         ;
 
         $tester = new CommandTester($this->getCommand($generator, $input));
@@ -59,6 +61,7 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
             ->expects($this->once())
             ->method('generate')
             ->with($this->getBundle(), $entity, $format, $fields)
+            ->willReturn(new EntityGeneratorResult('', '', ''))
         ;
         $generator
             ->expects($this->any())


### PR DESCRIPTION
This helps to keep the *Entity* namespace free from non-entity classes and to use the same structure as in the new Symfony demo application (see https://github.com/symfony/symfony-demo/issues/24). It should be BC, since the Repositories are still generated in *Entity* namespace per default.