### PR TITLE
Fix template vars of crud views

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -219,6 +219,8 @@ class DoctrineCrudGenerator extends Generator
         $this->renderFile('crud/views/index.html.twig.twig', $dir.'/index.html.twig', array(
             'bundle'            => $this->bundle->getName(),
             'entity'            => $this->entity,
+            'entity_pluralized' => $this->entityPluralized,
+            'entity_singularized' => $this->entitySingularized,
             'identifier'        => $this->metadata->identifier[0],
             'fields'            => $this->metadata->fieldMappings,
             'actions'           => $this->actions,
@@ -238,6 +240,7 @@ class DoctrineCrudGenerator extends Generator
         $this->renderFile('crud/views/show.html.twig.twig', $dir.'/show.html.twig', array(
             'bundle'            => $this->bundle->getName(),
             'entity'            => $this->entity,
+            'entity_singularized' => $this->entitySingularized,
             'identifier'        => $this->metadata->identifier[0],
             'fields'            => $this->metadata->fieldMappings,
             'actions'           => $this->actions,
@@ -256,6 +259,7 @@ class DoctrineCrudGenerator extends Generator
         $this->renderFile('crud/views/new.html.twig.twig', $dir.'/new.html.twig', array(
             'bundle'            => $this->bundle->getName(),
             'entity'            => $this->entity,
+            'entity_singularized' => $this->entitySingularized,
             'route_prefix'      => $this->routePrefix,
             'route_name_prefix' => $this->routeNamePrefix,
             'actions'           => $this->actions,
@@ -274,6 +278,7 @@ class DoctrineCrudGenerator extends Generator
             'route_name_prefix' => $this->routeNamePrefix,
             'identifier'        => $this->metadata->identifier[0],
             'entity'            => $this->entity,
+            'entity_singularized' => $this->entitySingularized,
             'fields'            => $this->metadata->fieldMappings,
             'bundle'            => $this->bundle->getName(),
             'actions'           => $this->actions,

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -19,21 +19,21 @@
             </tr>
         </thead>
         <tbody>
-        {{ '{% for entity in entities %}' }}
+        {{ '{% for ' ~ entity_singularized ~ ' in ' ~ entity_pluralized ~ ' %}' }}
             <tr>
 
         {%- for field, metadata in fields %}
             {%- if loop.first and ('show' in actions) %}
 
-                <td><a href="{{ "{{ path('" ~ route_name_prefix ~ "_show', { 'id': entity."~ identifier ~" }) }}" }}">{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</a></td>
+                <td><a href="{{ "{{ path('" ~ route_name_prefix ~ "_show', { 'id': " ~ entity_singularized ~ "."~ identifier ~" }) }}" }}">{{ '{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' }}' }}</a></td>
 
             {%- elseif metadata.type in ['date', 'datetime'] %}
 
-                <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
+                <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
 
             {%- else %}
 
-                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
+                <td>{{ '{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
 
             {%- endif %}
 

--- a/Resources/skeleton/crud/views/others/actions.html.twig.twig
+++ b/Resources/skeleton/crud/views/others/actions.html.twig.twig
@@ -4,7 +4,7 @@
                 {%- for action in record_actions %}
 
                     <li>
-                        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_" ~ action ~ "', { 'id': entity."~ identifier ~" }) }}" }}">{{ action }}</a>
+                        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_" ~ action ~ "', { 'id': " ~ entity_singularized ~ "."~ identifier ~" }) }}" }}">{{ action }}</a>
                     </li>
 
                 {%- endfor %}

--- a/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
+++ b/Resources/skeleton/crud/views/others/record_actions.html.twig.twig
@@ -6,7 +6,7 @@
     </li>
 {% if ('edit' in actions) and (not hide_edit) %}
     <li>
-        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_edit', { 'id': entity."~ identifier ~" }) }}" }}">
+        <a href="{{ "{{ path('" ~ route_name_prefix ~ "_edit', { 'id': " ~ entity_singularized ~ "."~ identifier ~" }) }}" }}">
             Edit
         </a>
     </li>

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -15,11 +15,11 @@
 
             {%- if metadata.type in ['date', 'datetime'] %}
 
-                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}' }}</td>
+                <td>{{ '{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}' }}</td>
 
             {%- else %}
 
-                <td>{{ '{{ entity.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
+                <td>{{ '{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' }}' }}</td>
 
             {%- endif %}
 


### PR DESCRIPTION
As of #292 the variables in the generated templates don't match the variables passed in the generated controller.

```
Variable "entities" does not exist in src/AppBundle/Resources/views/Subject/index.html.twig
```