### PR TITLE
Generate configureOptions method on form type

### DIFF
--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -82,6 +82,10 @@ class DoctrineFormGenerator extends Generator
             'bundle'           => $bundle->getName(),
             'form_class'       => $this->className,
             'form_type_name'   => strtolower(str_replace('\\', '_', $bundle->getNamespace()).($parts ? '_' : '').implode('_', $parts).'_'.substr($this->className, 0, -4)),
+
+            // Add 'setDefaultOptions' method with deprecated type hint, if the new 'configureOptions' isn't available.
+            // Required as long as Symfony 2.6 is supported.
+            'configure_options_available' => method_exists('Symfony\Component\Form\AbstractType', 'configureOptions'),
         ));
     }
 

--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -5,7 +5,10 @@ namespace {{ namespace }}\Form{{ entity_namespace ? '\\' ~ entity_namespace : ''
 {% block use_statements %}
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+{% if not configure_options_available %}
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+{% endif %}
+use Symfony\Component\OptionsResolver\OptionsResolver;
 {% endblock use_statements %}
 
 {% block class_definition %}
@@ -30,10 +33,25 @@ class {{ form_class }} extends AbstractType
     }
     {% endif %}
 
+    {%- if not configure_options_available %}
+
     /**
+     * Sets the default options for this type.
+     *
+     * This method should be removed when upgrading to Symfony 2.7.
+     *
      * @param OptionsResolverInterface $resolver
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+    {% endif %}
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => '{{ namespace }}\Entity{{ entity_namespace ? '\\' ~ entity_namespace : '' }}\{{ entity_class }}'


### PR DESCRIPTION
This avoids the generation of deprecated `setDefaultOptions` method in SF 2.7. If the `configureOptions` method isn't available, as in SF 2.6, the generated form type will be forward compatible.