### PR TITLE
[GenerateDoctrineEntityCommand] Added option to set id generator strategy

### DIFF
--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -207,4 +207,21 @@ class Validators
             'unset',
         );
     }
+
+    /**
+     * @param string $idStrategy
+     *
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function validateEntityIdGenerationStrategy($idStrategy)
+    {
+        $allowedStrategies = array('AUTO', 'SEQUENCE', 'IDENTITY', 'UUID', 'TABLE', 'NONE');
+        if (!in_array($idStrategy, $allowedStrategies)) {
+            throw new \InvalidArgumentException(sprintf('The identifier generation strategy must be one of "%s" ("%s" given)', implode('", "', $allowedStrategies), $idStrategy));
+        }
+
+        return $idStrategy;
+    }
 }

--- a/Generator/DoctrineEntityGenerator.php
+++ b/Generator/DoctrineEntityGenerator.php
@@ -47,8 +47,12 @@ class DoctrineEntityGenerator extends Generator
      *
      * @throws \Doctrine\ORM\Tools\Export\ExportException
      */
-    public function generate(BundleInterface $bundle, $entity, $format, array $fields)
+    public function generate(BundleInterface $bundle, $entity, $format, array $fields, $generatorType = ClassMetadataInfo::GENERATOR_TYPE_AUTO)
     {
+        $idType = 'integer';
+        if (ClassMetadataInfo::GENERATOR_TYPE_UUID === $generatorType) {
+            $idType = 'string';
+        }
         // configure the bundle (needed if the bundle does not contain any Entities yet)
         $config = $this->registry->getManager(null)->getConfiguration();
         $config->setEntityNamespaces(array_merge(
@@ -64,8 +68,10 @@ class DoctrineEntityGenerator extends Generator
 
         $class = new ClassMetadataInfo($entityClass);
         $class->customRepositoryClassName = str_replace('\\Entity\\', '\\Repository\\', $entityClass).'Repository';
-        $class->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
-        $class->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+        $class->mapField(array('fieldName' => 'id', 'type' => $idType, 'id' => true));
+        if (ClassMetadataInfo::GENERATOR_TYPE_NONE !== $generatorType) {
+            $class->setIdGeneratorType($generatorType);
+        }
         foreach ($fields as $field) {
             $class->mapField($field);
         }

--- a/Resources/doc/commands/generate_doctrine_entity.rst
+++ b/Resources/doc/commands/generate_doctrine_entity.rst
@@ -52,3 +52,16 @@ Available Options
     .. code-block:: bash
 
         php app/console generate:doctrine:entity --format=annotation
+
+* ``--id-generator-strategy``: (**AUTO**) [values: AUTO, SEQUENCE, IDENTITY, UUID, TABLE or NONE] This
+  option determines the identifier generator strategy to use for the generated
+  doctrine entity. By default, the command uses the ``AUTO`` identifier generator
+  strategy:
+
+    .. code-block:: bash
+
+        php app/console generate:doctrine:entity --id-generator-strategy=AUTO
+
+.. versionadded:: 3.0
+    The ``id-generator-strategy`` option was added in version 3.0. Previously,
+    the default value was always used.

--- a/Tests/Command/GenerateDoctrineEntityCommandTest.php
+++ b/Tests/Command/GenerateDoctrineEntityCommandTest.php
@@ -22,13 +22,13 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
      */
     public function testInteractiveCommand($options, $input, $expected)
     {
-        list($entity, $format, $fields) = $expected;
+        list($entity, $format, $idGeneratorStrategy, $fields) = $expected;
 
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
             ->method('generate')
-            ->with($this->getBundle(), $entity, $format, $fields)
+            ->with($this->getBundle(), $entity, $format, $fields, $idGeneratorStrategy)
             ->willReturn(new EntityGeneratorResult('', '', ''))
         ;
 
@@ -39,10 +39,10 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
     public function getInteractiveCommandData()
     {
         return array(
-            array(array(), "AcmeBlogBundle:Blog/Post\n", array('Blog\\Post', 'annotation', array())),
-            array(array('--entity' => 'AcmeBlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', array())),
-            array(array(), "AcmeBlogBundle:Blog/Post\nyml\n\n", array('Blog\\Post', 'yml', array())),
-            array(array(), "AcmeBlogBundle:Blog/Post\nyml\ncreated_by\n\n255\nfalse\nfalse\ndescription\ntext\nfalse\ntrue\nupdated_at\ndatetime\ntrue\nfalse\nrating\ndecimal\n5\n3\nfalse\nfalse\n\n", array('Blog\\Post', 'yml', array(
+            array(array(), "AcmeBlogBundle:Blog/Post\n", array('Blog\\Post', 'annotation', 'AUTO', array())),
+            array(array('--entity' => 'AcmeBlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', 'AUTO', array())),
+            array(array(), "AcmeBlogBundle:Blog/Post\nyml\n\n", array('Blog\\Post', 'yml', 'AUTO', array())),
+            array(array(), "AcmeBlogBundle:Blog/Post\nyml\nSEQUENCE\ncreated_by\n\n255\nfalse\nfalse\ndescription\ntext\nfalse\ntrue\nupdated_at\ndatetime\ntrue\nfalse\nrating\ndecimal\n5\n3\nfalse\nfalse\n\n", array('Blog\\Post', 'yml', 'SEQUENCE', array(
                 array('fieldName' => 'createdBy', 'type' => 'string', 'length' => 255, 'columnName' => 'created_by'),
                 array('fieldName' => 'description', 'type' => 'text', 'unique' => true, 'columnName' => 'description'),
                 array('fieldName' => 'updatedAt', 'type' => 'datetimetz', 'nullable' => true, 'columnName' => 'updated_at'),

--- a/Tests/Generator/DoctrineEntityGeneratorTest.php
+++ b/Tests/Generator/DoctrineEntityGeneratorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineEntityGenerator;
 
 class DoctrineEntityGeneratorTest extends GeneratorTest
@@ -98,7 +99,7 @@ class DoctrineEntityGeneratorTest extends GeneratorTest
 
     protected function generate($format)
     {
-        $this->getGenerator()->generate($this->getBundle(), 'Foo', $format, $this->getFields());
+        $this->getGenerator()->generate($this->getBundle(), 'Foo', $format, $this->getFields(), ClassMetadataInfo::GENERATOR_TYPE_AUTO);
     }
 
     protected function getGenerator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Allows to specify identifier generator strategy while creating a new entity:

```
$ app/console doctrine:generate:entity

  Welcome to the Doctrine2 entity generator

This command helps you generate Doctrine2 entities.

First, you need to give the entity name you want to generate.
You must use the shortcut notation like AcmeBlogBundle:Post.

The Entity shortcut name: AcmeBlogBundle:Post

Determine the format to use for the mapping information.

Configuration format (yml, xml, php, or annotation) [annotation]:

Determine the identifier generation strategy to use as entity id.

Identifier generation strategy (AUTO, SEQUENCE, IDENTITY, UUID, TABLE or NONE) [AUTO]:

Instead of starting with a blank entity, you can add some fields now.
Note that the primary key will be added automatically (named id, which uses the AUTO generation strategy).

Available types: array, simple_array, json_array, object,
boolean, integer, smallint, bigint, string, text, datetime, datetimetz,
date, time, decimal, float, binary, blob, guid, json.

New field name (press <return> to stop adding fields):

```

It should be merged after #361 since it uses the 5th argument for ```DoctrineEntityGenerator::generate()```, which previously was used for ```$with_repository``` param.