### PR TITLE
[minor] Updated config for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: php
 
-before_script:
+sudo: false
+
+before_install:
+    - composer self-update
+
+install:
     - composer install --dev --prefer-source
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+matrix:
+    include:
+        - php: 5.3.3
+        - php: 5.3
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+        - php: nightly
+        - php: hhvm
+    allow_failures:
+        - php: nightly
+        - php: hhvm
+    fast_finish: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Updated ```.travis.yml``` in order to run tests for nightly version of PHP, allowing
failures in ```hhvm``` and ```nightly```.
Also, this adds ```fast_finish``` flag and enforces to use the last available
version of Composer.