### PR TITLE
generate:bundle Update link to documentation in Configuration.php

### DIFF
--- a/Resources/skeleton/bundle/Configuration.php.twig
+++ b/Resources/skeleton/bundle/Configuration.php.twig
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * This is the class that validates and merges configuration from your app/config files
 {% endblock phpdoc_class_header %}
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
  */
 {% block class_definition %}
 class Configuration implements ConfigurationInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets? | 
| License | MIT
| Doc PR | 

When generating a new bundle, the same PSR2 warning occurs in **DependencyInjection\Configuration.php** file.
Moreover, the link to the documentation is obsolete.

- Update **link to documentation** (which has been moved)
- Fix this **PSR2 warning** the same way:

```
FILE: ...src/Acme/TestBundle/DependencyInjection/Configuration.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 11 | WARNING | Line exceeds 120 characters; contains 131 characters
----------------------------------------------------------------------
```