### PR TITLE
Make the RoutingManipulator code more robust

### DIFF
--- a/Manipulator/RoutingManipulator.php
+++ b/Manipulator/RoutingManipulator.php
@@ -52,7 +52,7 @@ class RoutingManipulator extends Manipulator
             $current = file_get_contents($this->file);
 
             // Don't add same bundle twice
-            if (false !== strpos($current, $code)) {
+            if (false !== strpos($current, '@'.$bundle)) {
                 throw new \RuntimeException(sprintf('Bundle "%s" is already imported.', $bundle));
             }
         } elseif (!is_dir($dir = dirname($this->file))) {


### PR DESCRIPTION
### Problem

The routing manipulator fails in some cases. The issue is described in #164.

### How to reproduce

```bash
$ dev generate:bundle --namespace=ThirdPartyUserBundle
```

Correctly generates this:

```yaml
third_party_user:
    resource: "@ThirdPartyUserBundle/Controller/"
    type:     annotation
    prefix:   /
```

But if you now try to generate a bundle without vendor:

```bash
$ dev generate:bundle --namespace=UserBundle
```

```bash
  ERROR
  The command was not able to configure everything automatically.
  You must do the following changes manually.
```

Why? Because the code looks for `user:\n` in the existing routing file ... and that's wrongly matched by `third_party_user:\n`

### Solution

Change this line:

```php
if (false !== strpos($current, $code)) { ... }
```

By the following:

```php 
if (false !== strpos($current, '@'.$bundle)) {
```

Now, the code will look for `@UserBundle` instead of `user:\n`. This should work right regardless of the routing format used.
