### PR TITLE
Simplify the initial code of generated bundles

### DIFF
--- a/Resources/skeleton/bundle/DefaultController.php.twig
+++ b/Resources/skeleton/bundle/DefaultController.php.twig
@@ -16,12 +16,12 @@ class DefaultController extends Controller
 {% block class_body %}
     {% if 'annotation' == format -%}
     /**
-     * @Route("/hello/{name}")
+     * @Route("/")
      */
     {% endif -%}
-    public function indexAction($name)
+    public function indexAction()
     {
-        return $this->render('{{ bundle }}:Default:index.html.twig', array('name' => $name));
+        return $this->render('{{ bundle }}:Default:index.html.twig');
     }
 {% endblock class_body %}
 }

--- a/Resources/skeleton/bundle/DefaultControllerTest.php.twig
+++ b/Resources/skeleton/bundle/DefaultControllerTest.php.twig
@@ -17,7 +17,7 @@ class DefaultControllerTest extends WebTestCase
 
         $crawler = $client->request('GET', '/');
 
-        $this->assertTrue($crawler->filter('html:contains("Hello World")')->count() > 0);
+        $this->assertContains('Hello World', $client->getResponse()->getContent());
     }
 {% endblock class_body %}
 }

--- a/Resources/skeleton/bundle/DefaultControllerTest.php.twig
+++ b/Resources/skeleton/bundle/DefaultControllerTest.php.twig
@@ -15,9 +15,9 @@ class DefaultControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $crawler = $client->request('GET', '/hello/Fabien');
+        $crawler = $client->request('GET', '/');
 
-        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+        $this->assertTrue($crawler->filter('html:contains("Hello World")')->count() > 0);
     }
 {% endblock class_body %}
 }

--- a/Resources/skeleton/bundle/index.html.twig.twig
+++ b/Resources/skeleton/bundle/index.html.twig.twig
@@ -1,1 +1,1 @@
-Hello {% raw %}{{ name }}{% endraw %}!
+Hello World!

--- a/Resources/skeleton/bundle/routing.php.twig
+++ b/Resources/skeleton/bundle/routing.php.twig
@@ -10,7 +10,7 @@ $collection = new RouteCollection();
 {% endblock definition %}
 
 {% block body %}
-$collection->add('{{ extension_alias }}_homepage', new Route('/hello/{name}', array(
+$collection->add('{{ extension_alias }}_homepage', new Route('/', array(
     '_controller' => '{{ bundle }}:Default:index',
 )));
 {% endblock body %}

--- a/Resources/skeleton/bundle/routing.xml.twig
+++ b/Resources/skeleton/bundle/routing.xml.twig
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
 {% block body %}
-    <route id="{{ extension_alias }}_homepage" path="/hello/{name}">
+    <route id="{{ extension_alias }}_homepage" path="/">
         <default key="_controller">{{ bundle }}:Default:index</default>
     </route>
 {% endblock body %}

--- a/Resources/skeleton/bundle/routing.yml.twig
+++ b/Resources/skeleton/bundle/routing.yml.twig
@@ -1,3 +1,3 @@
 {{ extension_alias }}_homepage:
-    path:     /hello/{name}
+    path:     /
     defaults: { _controller: {{ bundle }}:Default:index }

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -43,7 +43,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->assertNotContains('@Route("/hello/{name}"', $content);
 
         $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Resources/views/Default/index.html.twig');
-        $this->assertContains('Hello {{ name }}!', $content);
+        $this->assertContains('Hello World!', $content);
 
         $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Resources/config/services.yml');
         $this->assertContains('class: Foo\BarBundle\Example', $content);
@@ -81,7 +81,7 @@ class BundleGeneratorTest extends GeneratorTest
         $this->assertFalse(file_exists($this->tmpDir.'/Foo/BarBundle/Resources/config/routing.xml'));
 
         $content = file_get_contents($this->tmpDir.'/Foo/BarBundle/Controller/DefaultController.php');
-        $this->assertContains('@Route("/hello/{name}"', $content);
+        $this->assertContains('@Route("/")', $content);
     }
 
     public function testDirIsFile()


### PR DESCRIPTION
In the past, generated bundles were a good opportunity to show Symfony features (such as the routing parameters). Nowadays we have the pre-generated AppBundle and the Symfony Demo application, so we can make the generated bundles as clean as possible.