### PR TITLE
Generate services.yml instead of services.xml when using annotations

### DIFF
--- a/Resources/skeleton/bundle/Extension.php.twig
+++ b/Resources/skeleton/bundle/Extension.php.twig
@@ -29,10 +29,10 @@ class {{ bundle_basename }}Extension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        {% if format == 'yml' -%}
+        {% if format == 'yml' or format == 'annotation' -%}
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
-        {%- elseif format == 'xml' or format == 'annotation' -%}
+        {%- elseif format == 'xml' -%}
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
         {%- elseif format == 'php' -%}


### PR DESCRIPTION
In the past, `services.xml` was generated when using the annotation format. This was changed recently to generate `services.yml` instead. The problem is that the DI extension class was still trying to load `services.yml`.