### PR TITLE
Fixed an error with datetime fields in forms generated for CRUD

### DIFF
--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -76,6 +76,7 @@ class DoctrineFormGenerator extends Generator
 
         $this->renderFile('form/FormType.php.twig', $this->classPath, array(
             'fields'           => $this->getFieldsFromMetadata($metadata),
+            'fields_mapping'   => $metadata->fieldMappings,
             'namespace'        => $bundle->getNamespace(),
             'entity_namespace' => implode('\\', $parts),
             'entity_class'     => $entityClass,

--- a/Generator/DoctrineFormGenerator.php
+++ b/Generator/DoctrineFormGenerator.php
@@ -56,11 +56,11 @@ class DoctrineFormGenerator extends Generator
      */
     public function generate(BundleInterface $bundle, $entity, ClassMetadataInfo $metadata)
     {
-        $parts       = explode('\\', $entity);
+        $parts = explode('\\', $entity);
         $entityClass = array_pop($parts);
 
         $this->className = $entityClass.'Type';
-        $dirPath         = $bundle->getPath().'/Form';
+        $dirPath = $bundle->getPath().'/Form';
         $this->classPath = $dirPath.'/'.str_replace('\\', '/', $entity).'Type.php';
 
         if (file_exists($this->classPath)) {
@@ -75,14 +75,14 @@ class DoctrineFormGenerator extends Generator
         array_pop($parts);
 
         $this->renderFile('form/FormType.php.twig', $this->classPath, array(
-            'fields'           => $this->getFieldsFromMetadata($metadata),
-            'fields_mapping'   => $metadata->fieldMappings,
-            'namespace'        => $bundle->getNamespace(),
+            'fields' => $this->getFieldsFromMetadata($metadata),
+            'fields_mapping' => $metadata->fieldMappings,
+            'namespace' => $bundle->getNamespace(),
             'entity_namespace' => implode('\\', $parts),
-            'entity_class'     => $entityClass,
-            'bundle'           => $bundle->getName(),
-            'form_class'       => $this->className,
-            'form_type_name'   => strtolower(str_replace('\\', '_', $bundle->getNamespace()).($parts ? '_' : '').implode('_', $parts).'_'.substr($this->className, 0, -4)),
+            'entity_class' => $entityClass,
+            'bundle' => $bundle->getName(),
+            'form_class' => $this->className,
+            'form_type_name' => strtolower(str_replace('\\', '_', $bundle->getNamespace()).($parts ? '_' : '').implode('_', $parts).'_'.substr($this->className, 0, -4)),
 
             // Add 'setDefaultOptions' method with deprecated type hint, if the new 'configureOptions' isn't available.
             // Required as long as Symfony 2.6 is supported.
@@ -94,8 +94,9 @@ class DoctrineFormGenerator extends Generator
      * Returns an array of fields. Fields can be both column fields and
      * association fields.
      *
-     * @param  ClassMetadataInfo $metadata
-     * @return array             $fields
+     * @param ClassMetadataInfo $metadata
+     *
+     * @return array $fields
      */
     private function getFieldsFromMetadata(ClassMetadataInfo $metadata)
     {

--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -24,9 +24,17 @@ class {{ form_class }} extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-        {%- for field in fields %}
+
+        {%- for field in fields -%}
+            {%- if fields_mapping[field]['type'] in ['date', 'time', 'datetime'] %}
+
+            ->add('{{ field }}', '{{ fields_mapping[field]['type'] }}')
+
+            {%- else %}
 
             ->add('{{ field }}')
+
+            {%- endif -%}
         {%- endfor %}
 
         ;

--- a/Tests/Generator/DoctrineFormGeneratorTest.php
+++ b/Tests/Generator/DoctrineFormGeneratorTest.php
@@ -26,7 +26,13 @@ class DoctrineFormGeneratorTest extends GeneratorTest
 
         $metadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataInfo')->disableOriginalConstructor()->getMock();
         $metadata->identifier = array('id');
-        $metadata->associationMappings = array('title' => array('type' => 'string'));
+        $metadata->fieldMappings = array(
+            'title' => array('type' => 'string'),
+            'createdAt' => array('type' => 'date'),
+            'publishedAt' => array('type' => 'time'),
+            'updatedAt' => array('type' => 'datetime'),
+        );
+        $metadata->associationMappings = $metadata->fieldMappings;
 
         $generator->generate($bundle, 'Post', $metadata);
 
@@ -34,6 +40,9 @@ class DoctrineFormGeneratorTest extends GeneratorTest
 
         $content = file_get_contents($this->tmpDir.'/Form/PostType.php');
         $this->assertContains('->add(\'title\')', $content);
+        $this->assertContains('->add(\'createdAt\', \'date\')', $content);
+        $this->assertContains('->add(\'publishedAt\', \'time\')', $content);
+        $this->assertContains('->add(\'updatedAt\', \'datetime\')', $content);
         $this->assertContains('class PostType extends AbstractType', $content);
         $this->assertContains("'data_class' => 'Foo\BarBundle\Entity\Post'", $content);
         $this->assertContains("'foo_barbundle_post'", $content);


### PR DESCRIPTION
This fixes #223.

Taking the `Post` entity of the Symfony Demo app as an example, the original code generated the following form:

```php
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('title')
            ->add('slug')
            ->add('summary')
            ->add('content')
            ->add('authorEmail')
            ->add('publishedAt')
        ;
    }
```

This produced the following error:

![datetime_error](https://cloud.githubusercontent.com/assets/73419/8745744/1d00d22e-2c83-11e5-97be-438bd45d5637.png)

Now the datetime field is correctly generated:

```php
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('title')
            ->add('slug')
            ->add('summary')
            ->add('content')
            ->add('authorEmail')
            ->add('publishedAt', 'datetime')
        ;
    }
```