### PR TITLE
replaced hardcoded command names in help

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -36,6 +36,8 @@ class GenerateBundleCommand extends GeneratorCommand
     protected function configure()
     {
         $this
+            ->setName('generate:bundle')
+            ->setDescription('Generates a bundle')
             ->setDefinition(array(
                 new InputOption('namespace', '', InputOption::VALUE_REQUIRED, 'The namespace of the bundle to create'),
                 new InputOption('dir', '', InputOption::VALUE_REQUIRED, 'The directory where to create the bundle', 'src/'),
@@ -43,28 +45,26 @@ class GenerateBundleCommand extends GeneratorCommand
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)'),
                 new InputOption('shared', '', InputOption::VALUE_NONE, 'Are you planning on sharing this bundle across multiple applications?'),
             ))
-            ->setDescription('Generates a bundle')
             ->setHelp(<<<EOT
-The <info>generate:bundle</info> command helps you generates new bundles.
+The <info>%command.name%</info> command helps you generates new bundles.
 
 By default, the command interacts with the developer to tweak the generation.
 Any passed option will be used as a default value for the interaction
 (<comment>--namespace</comment> is the only one needed if you follow the
 conventions):
 
-<info>php app/console generate:bundle --namespace=Acme/BlogBundle</info>
+<info>php %command.full_name% --namespace=Acme/BlogBundle</info>
 
 Note that you can use <comment>/</comment> instead of <comment>\\ </comment>for the namespace delimiter to avoid any
 problems.
 
 If you want to disable any user interaction, use <comment>--no-interaction</comment> but don't forget to pass all needed options:
 
-<info>php app/console generate:bundle --namespace=Acme/BlogBundle --dir=src [--bundle-name=...] --no-interaction</info>
+<info>php %command.full_name% --namespace=Acme/BlogBundle --dir=src [--bundle-name=...] --no-interaction</info>
 
 Note that the bundle namespace must end with "Bundle".
 EOT
             )
-            ->setName('generate:bundle')
         ;
     }
 

--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -31,27 +31,28 @@ class GenerateControllerCommand extends GeneratorCommand
     public function configure()
     {
         $this
+            ->setName('generate:controller')
+            ->setDescription('Generates a controller')
             ->setDefinition(array(
                 new InputOption('controller', '', InputOption::VALUE_REQUIRED, 'The name of the controller to create'),
                 new InputOption('route-format', '', InputOption::VALUE_REQUIRED, 'The format that is used for the routing (yml, xml, php, annotation)', 'annotation'),
                 new InputOption('template-format', '', InputOption::VALUE_REQUIRED, 'The format that is used for templating (twig, php)', 'twig'),
                 new InputOption('actions', '', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The actions in the controller'),
             ))
-            ->setDescription('Generates a controller')
             ->setHelp(<<<EOT
-The <info>generate:controller</info> command helps you generates new controllers
+The <info>%command.name%</info> command helps you generates new controllers
 inside bundles.
 
 By default, the command interacts with the developer to tweak the generation.
 Any passed option will be used as a default value for the interaction
 (<comment>--controller</comment> is the only one needed if you follow the conventions):
 
-<info>php app/console generate:controller --controller=AcmeBlogBundle:Post</info>
+<info>php %command.full_name% --controller=AcmeBlogBundle:Post</info>
 
 If you want to disable any user interaction, use <comment>--no-interaction</comment>
 but don't forget to pass all needed options:
 
-<info>php app/console generate:controller --controller=AcmeBlogBundle:Post --no-interaction</info>
+<info>php %command.full_name% --controller=AcmeBlogBundle:Post --no-interaction</info>
 
 Every generated file is based on a template. There are default templates but they can
 be overriden by placing custom templates in one of the following locations, by order of priority:
@@ -63,7 +64,6 @@ You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resour
 in order to know the file structure of the skeleton
 EOT
             )
-            ->setName('generate:controller')
         ;
     }
 

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -40,6 +40,9 @@ class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
     protected function configure()
     {
         $this
+            ->setName('doctrine:generate:crud')
+            ->setAliases(array('generate:doctrine:crud'))
+            ->setDescription('Generates a CRUD based on a Doctrine entity')
             ->setDefinition(array(
                 new InputArgument('entity', InputArgument::OPTIONAL, 'The entity class name to initialize (shortcut notation)'),
                 new InputOption('entity', '', InputOption::VALUE_REQUIRED, 'The entity class name to initialize (shortcut notation)'),
@@ -48,13 +51,12 @@ class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation'),
                 new InputOption('overwrite', '', InputOption::VALUE_NONE, 'Do not stop the generation if crud controller already exist, thus overwriting all generated files'),
             ))
-            ->setDescription('Generates a CRUD based on a Doctrine entity')
             ->setHelp(<<<EOT
-The <info>doctrine:generate:crud</info> command generates a CRUD based on a Doctrine entity.
+The <info>%command.name%</info> command generates a CRUD based on a Doctrine entity.
 
 The default command only generates the list and show actions.
 
-<info>php app/console doctrine:generate:crud --entity=AcmeBlogBundle:Post --route-prefix=post_admin</info>
+<info>php %command.full_name% --entity=AcmeBlogBundle:Post --route-prefix=post_admin</info>
 
 Using the --with-write option allows to generate the new, edit and delete actions.
 
@@ -74,8 +76,6 @@ You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resour
 in order to know the file structure of the skeleton
 EOT
             )
-            ->setName('doctrine:generate:crud')
-            ->setAliases(array('generate:doctrine:crud'))
         ;
     }
 

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -37,10 +37,10 @@ class GenerateDoctrineEntityCommand extends GenerateDoctrineCommand
             ->addOption('fields', null, InputOption::VALUE_REQUIRED, 'The fields to create with the new entity')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation')
             ->setHelp(<<<EOT
-The <info>doctrine:generate:entity</info> task generates a new Doctrine
+The <info>%command.name%</info> task generates a new Doctrine
 entity inside a bundle:
 
-<info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post</info>
+<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post</info>
 
 The above command would initialize a new entity in the following entity
 namespace <info>Acme\BlogBundle\Entity\Blog\Post</info>.
@@ -53,16 +53,16 @@ entity:
 By default, the command uses annotations for the mapping information; change it
 with <comment>--format</comment>:
 
-<info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post --format=yml</info>
+<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=yml</info>
 
 To deactivate the interaction mode, simply use the <comment>--no-interaction</comment> option
 without forgetting to pass all needed options:
 
-<info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(255) body:text" --no-interaction</info>
+<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(255) body:text" --no-interaction</info>
 
 This also has support for passing field specific attributes:
 
-<info>php app/console doctrine:generate:entity --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(length=255 nullable=true unique=true) body:text ranking:decimal(precision:10 scale:0)" --no-interaction</info>
+<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(length=255 nullable=true unique=true) body:text ranking:decimal(precision:10 scale:0)" --no-interaction</info>
 EOT
         );
     }

--- a/Command/GenerateDoctrineFormCommand.php
+++ b/Command/GenerateDoctrineFormCommand.php
@@ -31,14 +31,16 @@ class GenerateDoctrineFormCommand extends GenerateDoctrineCommand
     protected function configure()
     {
         $this
+            ->setName('doctrine:generate:form')
+            ->setAliases(array('generate:doctrine:form'))
+            ->setDescription('Generates a form type class based on a Doctrine entity')
             ->setDefinition(array(
                 new InputArgument('entity', InputArgument::REQUIRED, 'The entity class name to initialize (shortcut notation)'),
             ))
-            ->setDescription('Generates a form type class based on a Doctrine entity')
             ->setHelp(<<<EOT
-The <info>doctrine:generate:form</info> command generates a form class based on a Doctrine entity.
+The <info>%command.name%</info> command generates a form class based on a Doctrine entity.
 
-<info>php app/console doctrine:generate:form AcmeBlogBundle:Post</info>
+<info>php %command.full_name% AcmeBlogBundle:Post</info>
 
 Every generated file is based on a template. There are default templates but they can be overriden by placing custom templates in one of the following locations, by order of priority:
 
@@ -49,8 +51,6 @@ You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resour
 in order to know the file structure of the skeleton
 EOT
             )
-            ->setName('doctrine:generate:form')
-            ->setAliases(array('generate:doctrine:form'))
         ;
     }
 
@@ -64,7 +64,7 @@ EOT
 
         $entityClass = $this->getContainer()->get('doctrine')->getAliasNamespace($bundle).'\\'.$entity;
         $metadata = $this->getEntityMetadata($entityClass);
-        $bundle   = $this->getApplication()->getKernel()->getBundle($bundle);
+        $bundle = $this->getApplication()->getKernel()->getBundle($bundle);
         $generator = $this->getGenerator($bundle);
 
         $generator->generate($bundle, $entity, $metadata[0]);


### PR DESCRIPTION
and moved command names and description to the top of the configure()-method