### PR TITLE
Added a new generate:command command

### DIFF
--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sensio\Bundle\GeneratorBundle\Generator\CommandGenerator;
 
 /**

--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -86,9 +86,10 @@ EOT
             ));
 
             $question = new Question($questionHelper->getQuestion('Bundle name', $bundle), $bundle);
-            $question->setValidator(function ($answer) {
+            $container = $this->getContainer();
+            $question->setValidator(function ($answer) use ($container) {
                 try {
-                   $b = $this->getContainer()->get('kernel')->getBundle($answer);
+                   $b = $container->get('kernel')->getBundle($answer);
                 } catch (\Exception $e) {
                     throw new \RuntimeException(sprintf('Bundle "%s" does not exist.', $answer));
                 }

--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -65,7 +65,10 @@ EOT
 
     public function interact(InputInterface $input, OutputInterface $output)
     {
-        if (null !== $bundle = $input->getArgument('bundle') && null !== $name = $input->getArgument('name')) {
+        $bundle = $input->getArgument('bundle');
+        $name = $input->getArgument('name');
+
+        if (null !== $bundle && null !== $name) {
             return;
         }
 
@@ -101,7 +104,7 @@ EOT
 
         // command name
         if (null !== $name) {
-            $output->writeln(sprintg('Command name: %s', $name));
+            $output->writeln(sprintf('Command name: %s', $name));
         } else {
             $output->writeln(array(
                 '',

--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -39,15 +39,15 @@ class GenerateCommandCommand extends GeneratorCommand
                 new InputArgument('name', InputArgument::OPTIONAL, 'The name of the command as you type it in the console (e.g. app:my-command)'),
             ))
             ->setHelp(<<<EOT
-The <info>generate:command</info> command helps you generates new commands
+The <info>generate:command</info> command helps you generate new commands
 inside bundles. Provide the bundle name as the first argument and the command
 name as the second argument:
 
-<info>php app/console generate:command AcmeBlogBundle blog:publish-posts</info>
+<info>php app/console generate:command AppBundle blog:publish-posts</info>
 
 If any of the arguments is missing, the command will ask for their values
 interactively. If you want to disable any user interaction, use
-<comment>--no-interaction</comment> but don't forget to pass all needed arguments.
+<comment>--no-interaction</comment>, but don't forget to pass all needed arguments.
 
 Every generated file is based on a template. There are default templates but they can
 be overriden by placing custom templates in one of the following locations, by order of priority:
@@ -56,7 +56,7 @@ be overriden by placing custom templates in one of the following locations, by o
 APP_PATH/Resources/SensioGeneratorBundle/skeleton/command</info>
 
 You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resources/skeleton
-in order to know the file structure of the skeleton
+in order to know the file structure of the skeleton.
 EOT
             )
         ;

--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Sensio\Bundle\GeneratorBundle\Generator\CommandGenerator;
+
+/**
+ * Generates commands.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class GenerateCommandCommand extends GeneratorCommand
+{
+    const MAX_ATTEMPTS = 5;
+
+    /**
+     * @see Command
+     */
+    public function configure()
+    {
+        $this
+            ->setName('generate:command')
+            ->setDescription('Generates a console command')
+            ->setDefinition(array(
+                new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle where the controller is generated'),
+                new InputArgument('name', InputArgument::OPTIONAL, 'The name of the command as you type it in the console (e.g. app:my-command)'),
+            ))
+            ->setHelp(<<<EOT
+The <info>generate:command</info> command helps you generates new commands
+inside bundles. Provide the bundle name as the first argument and the command
+name as the second argument:
+
+<info>php app/console generate:command AcmeBlogBundle blog:publish-posts</info>
+
+If any of the arguments is missing, the command will ask for their values
+interactively. If you want to disable any user interaction, use
+<comment>--no-interaction</comment> but don't forget to pass all needed arguments.
+
+Every generated file is based on a template. There are default templates but they can
+be overriden by placing custom templates in one of the following locations, by order of priority:
+
+<info>BUNDLE_PATH/Resources/SensioGeneratorBundle/skeleton/command
+APP_PATH/Resources/SensioGeneratorBundle/skeleton/command</info>
+
+You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resources/skeleton
+in order to know the file structure of the skeleton
+EOT
+            )
+        ;
+    }
+
+    public function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (null !== $bundle = $input->getArgument('bundle') && null !== $name = $input->getArgument('name')) {
+            return;
+        }
+
+        $questionHelper = $this->getQuestionHelper();
+        $questionHelper->writeSection($output, 'Welcome to the Symfony command generator');
+
+        // bundle
+        if (null !== $bundle) {
+            $output->writeln(sprintf('Bundle name: %s', $bundle));
+        } else {
+            $output->writeln(array(
+                '',
+                'First, you need to give the name of the bundle where the command will',
+                'be generated (e.g. <comment>AppBundle</comment>)',
+                '',
+            ));
+
+            $question = new Question($questionHelper->getQuestion('Bundle name', $bundle), $bundle);
+            $question->setValidator(function ($answer) {
+                try {
+                   $b = $this->getContainer()->get('kernel')->getBundle($answer);
+                } catch (\Exception $e) {
+                    throw new \RuntimeException(sprintf('Bundle "%s" does not exist.', $answer));
+                }
+
+                return $answer;
+            });
+            $question->setMaxAttempts(self::MAX_ATTEMPTS);
+
+            $bundle = $questionHelper->ask($input, $output, $question);
+            $input->setArgument('bundle', $bundle);
+        }
+
+        // command name
+        if (null !== $name) {
+            $output->writeln(sprintg('Command name: %s', $name));
+        } else {
+            $output->writeln(array(
+                '',
+                'Now, provide the name of the command as you type it in the console',
+                '(e.g. <comment>app:my-command</comment>)',
+                '',
+            ));
+
+            $question = new Question($questionHelper->getQuestion('Command name', $name), $name);
+            $question->setValidator(function ($answer) {
+                if (empty($answer)) {
+                   throw new \RuntimeException('The command name cannot be empty.');
+                }
+
+                return $answer;
+            });
+            $question->setMaxAttempts(self::MAX_ATTEMPTS);
+
+            $name = $questionHelper->ask($input, $output, $question);
+            $input->setArgument('name', $name);
+        }
+
+        // summary and confirmation
+        $output->writeln(array(
+            '',
+            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg-white', true),
+            '',
+            sprintf('You are going to generate a <info>%s</info> command inside <info>%s</info> bundle.', $name, $bundle),
+        ));
+
+        $question = new Question($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
+        if (!$questionHelper->ask($input, $output, $question)) {
+            $output->writeln('<error>Command aborted</error>');
+
+            return 1;
+        }
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $questionHelper = $this->getQuestionHelper();
+        $bundle = $input->getArgument('bundle');
+        $name = $input->getArgument('name');
+
+        try {
+            $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
+        } catch (\Exception $e) {
+            $output->writeln(sprintf('<bg=red>Bundle "%s" does not exist.</>', $bundle));
+        }
+
+        $generator = $this->getGenerator($bundle);
+        $generator->generate($bundle, $name);
+
+        $output->writeln(sprintf('Generated the <info>%s</info> command in <info>%s</info>', $name, $bundle->getName()));
+        $questionHelper->writeGeneratorSummary($output, array());
+    }
+
+    protected function createGenerator()
+    {
+        return new CommandGenerator($this->getContainer()->get('filesystem'));
+    }
+}

--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -35,8 +35,8 @@ class GenerateCommandCommand extends GeneratorCommand
             ->setName('generate:command')
             ->setDescription('Generates a console command')
             ->setDefinition(array(
-                new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle where the controller is generated'),
-                new InputArgument('name', InputArgument::OPTIONAL, 'The name of the command as you type it in the console (e.g. app:my-command)'),
+                new InputArgument('bundle', InputArgument::OPTIONAL, 'The bundle where the command is generated'),
+                new InputArgument('name', InputArgument::OPTIONAL, 'The command\'s name (e.g. app:my-command)'),
             ))
             ->setHelp(<<<EOT
 The <info>generate:command</info> command helps you generate new commands

--- a/Generator/CommandGenerator.php
+++ b/Generator/CommandGenerator.php
@@ -56,9 +56,9 @@ class CommandGenerator extends Generator
 
     /**
      * Transforms the given string to a new string valid as a PHP class name
-     * ('app:my-project' -> 'AppMyProject', 'app:namespace:name' -> 'AppNamespaceName')
+     * ('app:my-project' -> 'AppMyProject', 'app:namespace:name' -> 'AppNamespaceName').
      *
-     * @param  string $string
+     * @param string $string
      *
      * @return The string transformed to be a valid PHP class name
      */

--- a/Generator/CommandGenerator.php
+++ b/Generator/CommandGenerator.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Generator;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * Generates a Command inside a bundle.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class CommandGenerator extends Generator
+{
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param Filesystem $filesystem A Filesystem instance
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public function generate(BundleInterface $bundle, $name)
+    {
+        $bundleDir = $bundle->getPath();
+        $commandDir = $bundleDir.'/Command';
+        $this->filesystem->mkdir($commandDir);
+
+        $commandClassName = $this->classify($name).'Command';
+        $commandFile = $commandDir.'/'.$commandClassName.'.php';
+        if ($this->filesystem->exists($commandFile)) {
+            throw new \RuntimeException(sprintf('Command "%s" already exists', $name));
+        }
+
+        $parameters = array(
+            'namespace' => $bundle->getNamespace(),
+            'class_name' => $commandClassName,
+            'name' => $name,
+        );
+
+        $this->renderFile('command/Command.php.twig', $commandFile, $parameters);
+    }
+
+    /**
+     * Transforms the given string to a new string valid as a PHP class name
+     * ('app:my-project' -> 'AppMyProject', 'app:namespace:name' -> 'AppNamespaceName')
+     *
+     * @param  string $string
+     *
+     * @return The string transformed to be a valid PHP class name
+     */
+    public function classify($string)
+    {
+        return str_replace(' ', '', ucwords(strtr($string, '_-:', '   ')));
+    }
+}

--- a/Resources/doc/commands/generate_command.rst
+++ b/Resources/doc/commands/generate_command.rst
@@ -1,0 +1,28 @@
+Generating a New Command
+========================
+
+Usage
+-----
+
+The ``generate:command`` command generates a new Command class for the given
+console command.
+
+By default the command is run in the interactive mode and asks questions to
+determine the bundle and the command name:
+
+.. code-block:: bash
+
+    $ php app/console generate:command
+
+The command can be run in a non interactive mode by using the
+``--no-interaction`` and poviding the needed arguments:
+
+.. code-block:: bash
+
+    $ php app/console generate:command --no-interaction AcmeBlogBundle blog:publish-posts
+
+Available Arguments
+-------------------
+
+* ``bundle``: The name of the bundle where the command class is generated.
+* ``name``: The name of the command as you type it in the console.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -55,6 +55,7 @@ Read the following articles to learn how to use the new commands:
    :maxdepth: 1
 
    commands/generate_bundle
+   commands/generate_command
    commands/generate_controller
    commands/generate_doctrine_crud
    commands/generate_doctrine_entity

--- a/Resources/skeleton/command/Command.php.twig
+++ b/Resources/skeleton/command/Command.php.twig
@@ -1,0 +1,40 @@
+<?php
+
+namespace {{ namespace }}\Command;
+
+{% block use_statements %}
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ class_name }} extends ContainerAwareCommand
+{% endblock class_definition %}
+{
+{% block class_body %}
+    protected function configure()
+    {
+        $this
+            ->setName('{{ name }}')
+            ->setDescription('...')
+            ->addArgument('argument', InputArgument::OPTIONAL, 'Argument description')
+            ->addOption('option', null, InputOption::VALUE_NONE, 'Option description')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $argument = $input->getArgument('argument');
+
+        if ($input->getOption('option')) {
+            // ...
+        }
+
+        $output->writeln('Command result.');
+    }
+
+{% endblock class_body %}
+}

--- a/Tests/Command/GenerateCommandCommandTest.php
+++ b/Tests/Command/GenerateCommandCommandTest.php
@@ -45,25 +45,25 @@ class GenerateCommandCommandTest extends GenerateCommandTest
             array(
                 array(),
                 "FooBarBundle\napp:foo-bar\n",
-                array('FooBarBundle', 'app:foo-bar')
+                array('FooBarBundle', 'app:foo-bar'),
             ),
 
             array(
                 array('bundle' => 'FooBarBundle'),
                 "app:foo-bar\n",
-                array('FooBarBundle', 'app:foo-bar')
+                array('FooBarBundle', 'app:foo-bar'),
             ),
 
             array(
                 array('name' => 'app:foo-bar'),
                 "FooBarBundle\n",
-                array('FooBarBundle', 'app:foo-bar')
+                array('FooBarBundle', 'app:foo-bar'),
             ),
 
             array(
                 array('bundle' => 'FooBarBundle', 'name' => 'app:foo-bar'),
                 '',
-                array('FooBarBundle', 'app:foo-bar')
+                array('FooBarBundle', 'app:foo-bar'),
             ),
         );
     }
@@ -93,7 +93,7 @@ class GenerateCommandCommandTest extends GenerateCommandTest
         return array(
             array(
                 array('bundle' => 'FooBarBundle', 'name' => 'app:my-command'),
-                array('FooBarBundle', 'app:my-command')
+                array('FooBarBundle', 'app:my-command'),
             ),
         );
     }

--- a/Tests/Command/GenerateCommandCommandTest.php
+++ b/Tests/Command/GenerateCommandCommandTest.php
@@ -41,12 +41,10 @@ class GenerateCommandCommandTest extends GenerateCommandTest
 
     public function getInteractiveCommandData()
     {
-        $tmp = sys_get_temp_dir();
-
         return array(
             array(
                 array(),
-                "FooBarBundle\napp:my-command\n",
+                "FooBarBundle\napp:foo-bar\n",
                 array('FooBarBundle', 'app:foo-bar')
             ),
 

--- a/Tests/Command/GenerateCommandCommandTest.php
+++ b/Tests/Command/GenerateCommandCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Tests\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Sensio\Bundle\GeneratorBundle\Command\GenerateCommandCommand;
+
+class GenerateCommandCommandTest extends GenerateCommandTest
+{
+    protected $generator;
+    protected $bundle;
+    protected $tmpDir;
+
+    /**
+     * @dataProvider getInteractiveCommandData
+     */
+    public function testInteractiveCommand($options, $input, $expected)
+    {
+        list($bundle, $name) = $expected;
+
+        $generator = $this->getGenerator();
+        $generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->getBundle(), $name)
+        ;
+
+        $tester = $this->getCommandTester($generator, $input);
+        $tester->execute($options);
+    }
+
+    public function getInteractiveCommandData()
+    {
+        $tmp = sys_get_temp_dir();
+
+        return array(
+            array(
+                array(),
+                "FooBarBundle\napp:my-command\n",
+                array('FooBarBundle', 'app:foo-bar')
+            ),
+
+            array(
+                array('bundle' => 'FooBarBundle'),
+                "app:foo-bar\n",
+                array('FooBarBundle', 'app:foo-bar')
+            ),
+
+            array(
+                array('name' => 'app:foo-bar'),
+                "FooBarBundle\n",
+                array('FooBarBundle', 'app:foo-bar')
+            ),
+
+            array(
+                array('bundle' => 'FooBarBundle', 'name' => 'app:foo-bar'),
+                '',
+                array('FooBarBundle', 'app:foo-bar')
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getNonInteractiveCommandData
+     */
+    public function testNonInteractiveCommand($options, $expected)
+    {
+        list($bundle, $name) = $expected;
+
+        $generator = $this->getGenerator();
+        $generator
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->getBundle(), $name)
+        ;
+
+        $tester = $this->getCommandTester($generator);
+        $tester->execute($options, array('interactive' => false));
+    }
+
+    public function getNonInteractiveCommandData()
+    {
+        $tmp = sys_get_temp_dir();
+
+        return array(
+            array(
+                array('bundle' => 'FooBarBundle', 'name' => 'app:my-command'),
+                array('FooBarBundle', 'app:my-command')
+            ),
+        );
+    }
+
+    protected function getCommand($generator, $input)
+    {
+        $command = new GenerateCommandCommand();
+
+        $command->setContainer($this->getContainer());
+        $command->setHelperSet($this->getHelperSet($input));
+        $command->setGenerator($generator);
+
+        return $command;
+    }
+
+    protected function getCommandTester($generator, $input = '')
+    {
+        return new CommandTester($this->getCommand($generator, $input));
+    }
+
+    protected function getApplication($input = '')
+    {
+        $application = new Application();
+
+        $command = new GenerateCommandCommand();
+        $command->setContainer($this->getContainer());
+        $command->setHelperSet($this->getHelperSet($input));
+        $command->setGenerator($this->getGenerator());
+
+        $application->add($command);
+
+        return $application;
+    }
+
+    protected function getGenerator()
+    {
+        if (null === $this->generator) {
+            $this->setGenerator();
+        }
+
+        return $this->generator;
+    }
+
+    protected function setGenerator()
+    {
+        // get a noop generator
+        $this->generator = $this
+            ->getMockBuilder('Sensio\Bundle\GeneratorBundle\Generator\CommandGenerator')
+            ->disableOriginalConstructor()
+            ->setMethods(array('generate'))
+            ->getMock()
+        ;
+    }
+
+    protected function getBundle()
+    {
+        if (null == $this->bundle) {
+            $this->setBundle();
+        }
+
+        return $this->bundle;
+    }
+
+    protected function setBundle()
+    {
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
+        $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
+        $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));
+
+        $this->bundle = $bundle;
+    }
+}

--- a/Tests/Generator/CommandGeneratorTest.php
+++ b/Tests/Generator/CommandGeneratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensio\Bundle\GeneratorBundle\Tests\Generator;
+
+use Sensio\Bundle\GeneratorBundle\Generator\CommandGenerator;
+
+class CommandGeneratorTest extends GeneratorTest
+{
+    public function testGenerateController()
+    {
+        $commandName = 'app:foo-bar';
+        $commandFile = 'Command/AppFooBarCommand.php';
+        $commandPath = $this->tmpDir.'/'.$commandFile;
+
+        $this->getGenerator()->generate($this->getBundle(), $commandName);
+
+        $this->assertTrue(file_exists($commandPath), sprintf('%s file has been generated.', $commandFile));
+
+        $commandContent = file_get_contents($commandPath);
+        $strings = array(
+            'namespace Foo\\BarBundle\\Command',
+            'class AppFooBarCommand extends ContainerAwareCommand',
+            sprintf("->setName('%s')", $commandName),
+        );
+        foreach ($strings as $string) {
+            $this->assertContains($string, $commandContent);
+        }
+    }
+
+    /**
+     * @dataProvider getNames
+     */
+    public function testClassify($commandName, $className)
+    {
+        $generator = $this->getGenerator();
+        $this->assertEquals($className, $generator->classify($commandName));
+    }
+
+    public function getNames()
+    {
+        return array(
+            array('app', 'App'),
+            array('app-foo', 'AppFoo'),
+            array('app_foo', 'AppFoo'),
+            array('app:foo-bar', 'AppFooBar'),
+            array('app:foo:bar', 'AppFooBar'),
+            array('app:foo:bar-baz', 'AppFooBarBaz'),
+            array('app:foo:bar_baz', 'AppFooBarBaz'),
+            array('app-foo:bar-baz:foo-bar', 'AppFooBarBazFooBar'),
+        );
+    }
+
+    protected function getGenerator()
+    {
+        $generator = new CommandGenerator($this->filesystem);
+        $generator->setSkeletonDirs(__DIR__.'/../../Resources/skeleton');
+
+        return $generator;
+    }
+
+    protected function getBundle()
+    {
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
+        $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
+        $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));
+
+        return $bundle;
+    }
+}

--- a/Tests/Manipulator/KernelManipulatorTest.php
+++ b/Tests/Manipulator/KernelManipulatorTest.php
@@ -28,6 +28,10 @@ class KernelManipulatorTest extends GeneratorTest
      */
     public function testAddToArray($kernelOriginFilePath)
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Not supported in HHVM since it doesn\'t allow to lint PHP files.');
+        }
+
         $params = $this->prepareTestKernel($kernelOriginFilePath);
 
         list($kernelClassName, $fullpath) = $params;


### PR DESCRIPTION
This fixes #332.

If you execute the following:

```bash
$ php app/console generate:command AppBundle app:publish-posts
```

This command generates the following class:

```php
<?php

namespace AppBundle\Command;

use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;

class AppPublishPostsCommand extends ContainerAwareCommand
{
    protected function configure()
    {
        $this
            ->setName('app:publish-posts')
            ->setDescription('...')
            ->addArgument('argument', InputArgument::OPTIONAL, 'Argument description')
            ->addOption('option', null, InputOption::VALUE_NONE, 'Option description')
        ;
    }

    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $argument = $input->getArgument('argument');

        if ($input->getOption('option')) {
            // ...
        }

        $output->writeln('Command result.');
    }

}
```

**Note**  there ae two tests failing. I need help to solve this problem. Thanks!
