### PR TITLE
Don't allow failures for HHVM and PHP7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,4 @@ matrix:
         - php: 5.6
         - php: nightly
         - php: hhvm
-    allow_failures:
-        - php: nightly
-        - php: hhvm
     fast_finish: true


### PR DESCRIPTION
Would it make sense to follow Symfony's steps and don't allow failures for HHVM and PHP7?