### PR TITLE
Use Twig's include() as a function instead of as a tag

### DIFF
--- a/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -9,6 +9,6 @@
     {{ '{{ form(edit_form) }}' }}
 
     {% set hide_edit, hide_delete = true, false %}
-    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+    {{ include('crud/views/others/record_actions.html.twig.twig') }}
 {{ "{% endblock %}" }}
 {% endblock body %}

--- a/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/Resources/skeleton/crud/views/new.html.twig.twig
@@ -9,6 +9,6 @@
     {{ '{{ form(form) }}' }}
 
     {% set hide_edit, hide_delete = true, true %}
-    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+    {{ include('crud/views/others/record_actions.html.twig.twig') }}
 {{ "{% endblock %}" }}
 {% endblock body %}

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -39,6 +39,6 @@
     </table>
 
     {% set hide_edit, hide_delete = false, false %}
-    {% include 'crud/views/others/record_actions.html.twig.twig' %}
+    {{ include('crud/views/others/record_actions.html.twig.twig') }}
 {{ "{% endblock %}" }}
 {% endblock body %}


### PR DESCRIPTION
I know it's a minor change, but `{% include '...' %}` is deprecated in favor of `{{ include('...') }}`