### PR TITLE
Fixed handling of time-only and date-only types

### DIFF
--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -13,10 +13,18 @@
             <tr>
                 <th>{{ field|capitalize }}</th>
 
-            {%- if metadata.type in ['date', 'datetime'] %}
+            {%- if metadata.type in ['datetime'] %}
 
                 <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d H:i:s\') }}{% endif %}' }}</td>
 
+            {%- elseif metadata.type in ['date'] %}
+
+                <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'Y-m-d\') }}{% endif %}' }}</td>
+            
+            {%- elseif metadata.type in ['date'] %}
+
+                <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|date(\'H:i:s\') }}{% endif %}' }}</td>
+            
             {%- elseif metadata.type in ['array'] %}
 
                 <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}{{ entity.' ~ field|replace({'_': ''}) ~ '|join(\', \') }}{% endif %}' }}</td>


### PR DESCRIPTION
Added new cases for 'date' and 'time'.

Previously 'time' caused an error (cannot convert to string) and 'date' would render the unavailable time aspect as 00:00:00 unnecessarily