### PR TITLE
fix visibility of setFormat method

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -107,7 +107,7 @@ class DoctrineCrudGenerator extends Generator
      *
      * @param string $format The configuration format
      */
-    private function setFormat($format)
+    protected function setFormat($format)
     {
         switch ($format) {
             case 'yml':


### PR DESCRIPTION
This PR change the visibility of setFormat method.
This change is necessary if we need to extend the DoctrineCrudGenerator class.
If we redefine the generate method in our new class, we have an error because we call the setFormat method who is private.
The first solution is to change the visibility of setFormat method (that what i propose in this PR). The second solution is to duplicate the method in our new class (bad idea if we don't need to redefine it)
