### PR TITLE
Fixed KernelManipulator to work with PHP short array syntax.

### DIFF
--- a/Tests/Manipulator/KernelManipulatorTest.php
+++ b/Tests/Manipulator/KernelManipulatorTest.php
@@ -60,13 +60,25 @@ class KernelManipulatorTest extends GeneratorTest
      */
     public function kernelStubFilenamesProvider()
     {
-        return array(
+        $stubs = array(
             'With empty bundles array' => array(__DIR__.'/Stubs/EmptyBundlesKernelStub.php'),
             'With empty multiline bundles array' => array(__DIR__.'/Stubs/EmptyBundlesMultilineKernelStub.php'),
             'With bundles array contains comma' => array(__DIR__.'/Stubs/ContainsCommaKernelStub.php'),
             'With bundles added w/o trailing comma' => array(__DIR__.'/Stubs/ContainsBundlesKernelStub.php'),
             'With some extra code and bad formatted' => array(__DIR__.'/Stubs/ContainsExtraCodeKernelStub.php'),
+
         );
+
+        if(PHP_VERSION_ID >= 50400){
+            $stubs = array_merge($stubs, array(
+                'With empty bundles array, short array syntax' => array(__DIR__.'/Stubs/EmptyBundlesShortArraySyntaxKernelStub.php'),
+                'With empty multiline bundles array, short array syntax' => array(__DIR__.'/Stubs/EmptyBundlesMultilineShortArraySyntaxKernelStub.php'),
+                'With bundles array contains comma, short array syntax' => array(__DIR__.'/Stubs/ContainsCommaShortArraySyntaxKernelStub.php'),
+                'With bundles added w/o trailing comma, short array syntax' => array(__DIR__.'/Stubs/ContainsBundlesShortArraySyntaxKernelStub.php'),
+            ));
+        }
+
+        return $stubs;
     }
 
     /**

--- a/Tests/Manipulator/Stubs/ContainsBundlesShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/ContainsBundlesShortArraySyntaxKernelStub.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Sensio\Bundle\GeneratorBundle\Tests\Manipulator\Stubs\StubBundle;
+
+class ContainsBundlesShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        $bundles = [
+            new StubBundle(),
+            new StubBundle(),
+            new StubBundle(),
+        ];
+
+        return $bundles;
+    }
+}

--- a/Tests/Manipulator/Stubs/ContainsCommaShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/ContainsCommaShortArraySyntaxKernelStub.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Sensio\Bundle\GeneratorBundle\Tests\Manipulator\Stubs\StubBundle;
+
+class ContainsCommaShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        $bundles = [
+            new StubBundle(),
+        ];
+
+        return $bundles;
+    }
+}

--- a/Tests/Manipulator/Stubs/ContainsExtraCodeShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/ContainsExtraCodeShortArraySyntaxKernelStub.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Sensio\Bundle\GeneratorBundle\Tests\Manipulator\Stubs\StubBundle;
+
+class ContainsExtraCodeShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        $someVariable = false;
+
+        // some bad formatted definition
+        $bundles = [
+            new StubBundle(),
+
+            new StubBundle(),
+
+        ];
+
+        if (!$someVariable && in_array($this->getEnvironment(), array('dev', 'test'))) {
+            $bundles[] = new StubBundle();
+        }
+
+        return $bundles;
+    }
+}

--- a/Tests/Manipulator/Stubs/EmptyBundlesMultilineShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/EmptyBundlesMultilineShortArraySyntaxKernelStub.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+
+class EmptyBundlesMultilineShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        $bundles = [
+
+        ];
+
+        return $bundles;
+    }
+}

--- a/Tests/Manipulator/Stubs/EmptyBundlesShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/EmptyBundlesShortArraySyntaxKernelStub.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+
+class EmptyBundlesShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        $bundles = [];
+
+        return $bundles;
+    }
+}

--- a/Tests/Manipulator/Stubs/UsingShortArraySyntaxKernelStub.php
+++ b/Tests/Manipulator/Stubs/UsingShortArraySyntaxKernelStub.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KernelManipulatorTest\Stubs;
+
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Sensio\Bundle\GeneratorBundle\Tests\Manipulator\Stubs\StubBundle;
+
+class UsingShortArraySyntaxKernelStub extends KernelForTest
+{
+    public function registerBundles()
+    {
+        // short array syntax
+        $bundles = [
+            new StubBundle(),
+            new StubBundle(),
+        ];
+
+        if (!$someVariable && in_array($this->getEnvironment(), array('dev', 'test'))) {
+            $bundles[] = new StubBundle();
+        }
+
+        return $bundles;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #426
| License       | MIT
| Doc PR        | ?

The code in KernelManipulator does account for short array syntax but it's not working. 

I added a fix and added all test cases for short syntax - test could probably be done better, please advise.