### PR TITLE
Added a period at the end of the sentences to conform to Symfony specifications.

### DIFF
--- a/Resources/skeleton/bundle/Configuration.php.twig
+++ b/Resources/skeleton/bundle/Configuration.php.twig
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
 {% block phpdoc_class_header %}
- * This is the class that validates and merges configuration from your app/config files
+ * This is the class that validates and merges configuration from your app/config files.
 {% endblock phpdoc_class_header %}
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}

--- a/Resources/skeleton/bundle/Extension.php.twig
+++ b/Resources/skeleton/bundle/Extension.php.twig
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Loader;
 
 /**
 {% block phpdoc_class_header %}
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
 {% endblock phpdoc_class_header %}
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}


### PR DESCRIPTION
When running `php-cs-fixer` over Symfony generated bundles, it will find and correct two docblock sentences by adding periods to the end. This PR will automatically add these periods to the bundle skeleton, so at least the bundle generator generates code that conforms fully to the Symfony specification / php-cs-fixer.