### PR TITLE
Fix form generation for entities with ManyToOne relations

### DIFF
--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -26,7 +26,7 @@ class {{ form_class }} extends AbstractType
         $builder
 
         {%- for field in fields -%}
-            {%- if fields_mapping[field]['type'] in ['date', 'time', 'datetime'] %}
+            {%- if fields_mapping[field] is defined and fields_mapping[field]['type'] in ['date', 'time', 'datetime'] %}
 
             ->add('{{ field }}', '{{ fields_mapping[field]['type'] }}')
 


### PR DESCRIPTION
When trying to generate a Form Type for an Entity that has a `@ORM\ManyToOne` relation, a `Twig_Error_Runtime` is thrown:

> [Twig_Error_Runtime]
> Key "author" for array with keys "id, title" does not exist in "form/FormType.php.twig" at line 29

This happens because the associated field is returned by `DoctrineFormGenerator::getFieldsFromMetadata()`, but does not exists in `ClassMetadataInfo::$fieldMappings`.

This problem occurred in a project created with the Symfony installer (based on v2.8.0-BETA1) and can be reproduced with the entities below.

This pull request fixes the problem.

---

Composer package versions in project:
```
doctrine/annotations                 v1.2.7
doctrine/cache                       v1.5.1
doctrine/collections                 v1.3.0
doctrine/common                      v2.5.1
doctrine/dbal                        v2.5.2
doctrine/doctrine-bundle             1.6.0
doctrine/doctrine-cache-bundle       1.2.1
doctrine/inflector                   v1.1.0
doctrine/instantiator                1.0.5
doctrine/lexer                       v1.0.1
doctrine/orm                         v2.5.1
incenteev/composer-parameter-handler v2.1.2
ircmaxell/password-compat            v1.0.4
jdorn/sql-formatter                  v1.2.17
monolog/monolog                      1.17.2
paragonie/random_compat              1.1.0
psr/log                              1.0.0
sensio/distribution-bundle           dev-master 1045b31
sensio/framework-extra-bundle        v3.0.11
sensio/generator-bundle              v3.0.0
sensiolabs/security-checker          v3.0.2
swiftmailer/swiftmailer              v5.4.1
symfony/monolog-bundle               2.8.1
symfony/phpunit-bridge               v2.7.6
symfony/polyfill-intl-icu            v1.0.0
symfony/polyfill-mbstring            v1.0.0
symfony/polyfill-php54               v1.0.0
symfony/polyfill-php55               v1.0.0
symfony/polyfill-php56               v1.0.0
symfony/polyfill-php70               v1.0.0
symfony/polyfill-util                v1.0.0
symfony/security-acl                 v2.7.6
symfony/swiftmailer-bundle           v2.3.8
symfony/symfony                      2.8.x-dev 3b99b3a
twig/twig                            v1.23.1
```

```php
<?php

namespace AppBundle\Entity;

use Doctrine\ORM\Mapping as ORM;

/**
 * Book
 *
 * @ORM\Table(name="book")
 * @ORM\Entity(repositoryClass="AppBundle\Repository\BookRepository")
 */
class Book
{
    /**
     * @var int
     *
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;

    /**
     * @var string
     *
     * @ORM\Column(name="title", type="string", length=255, unique=true)
     */
    private $title;

    /**
     * @var Author
     *
     * @ORM\JoinColumn(name="author_id", referencedColumnName="id")
     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Author")
     */
    private $author;

    // getters and setters left out for conciseness
}
```
```php
<?php

namespace AppBundle\Entity;

use Doctrine\ORM\Mapping as ORM;

/**
 * Author
 *
 * @ORM\Table(name="author")
 * @ORM\Entity(repositoryClass="AppBundle\Repository\AuthorRepository")
 */
class Author
{
    /**
     * @var int
     *
     * @ORM\Column(name="id", type="integer")
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;

    /**
     * @var string
     *
     * @ORM\Column(name="name", type="string", length=255)
     */
    private $name;

    // getters and setters left out for conciseness
}
```