### PR TITLE
Set template name to snake_case.

### DIFF
--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -243,8 +243,10 @@ EOT
             $placeholders = $this->getPlaceholdersFromRoute($route);
 
             // template
-            $defaultTemplate = $input->getOption('controller').':'.substr($actionName, 0, -6).'.html.'.$input->getOption('template-format');
-            $question = new Question($questionHelper->getQuestion('Template name (optional)', $defaultTemplate), 'default');
+            $defaultTemplate = $input->getOption('controller').':'.
+                strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr(substr($actionName, 0, -6), '_', '.')))
+                .'.html.'.$input->getOption('template-format');
+            $question = new Question($questionHelper->getQuestion('Template name (optional)', $defaultTemplate), $defaultTemplate);
             $template = $questionHelper->ask($input, $output, $question);
 
             // adding action

--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -60,7 +60,10 @@ class ControllerGenerator extends Generator
             // create a template
             $template = $actions[$i]['template'];
             if ('default' == $template) {
-                $template = $bundle->getName().':'.$controller.':'.substr($action['name'], 0, -6).'.html.'.$templateFormat;
+                @trigger_error('The use of the "default" keyword is deprecated. Use the real template name instead.', E_USER_DEPRECATED);
+                $template = $bundle->getName().':'.$controller.':'.
+                    strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr(substr($actionName, 0, -6), '_', '.')))
+                    .'.html.'.$templateFormat;
             }
 
             if ('twig' == $templateFormat) {

--- a/Tests/Command/GenerateControllerCommandTest.php
+++ b/Tests/Command/GenerateControllerCommandTest.php
@@ -54,7 +54,7 @@ class GenerateControllerCommandTest extends GenerateCommandTest
                     'name' => 'showAction',
                     'route' => '/show',
                     'placeholders' => array(),
-                    'template' => 'default',
+                    'template' => 'AcmeBlogBundle:Post:show.html.php',
                 ),
                 'getListAction' => array(
                     'name' => 'getListAction',

--- a/Tests/Generator/ControllerGeneratorTest.php
+++ b/Tests/Generator/ControllerGeneratorTest.php
@@ -54,7 +54,7 @@ class ControllerGeneratorTest extends GeneratorTest
                 'name' => 'showPageAction',
                 'route' => '/{id}/{slug}',
                 'placeholders' => array('id', 'slug'),
-                'template' => 'default',
+                'template' => 'FooBarBundle:Page:show_page.html.twig',
             ),
             1 => array(
                 'name' => 'getListOfPagesAction',
@@ -67,7 +67,7 @@ class ControllerGeneratorTest extends GeneratorTest
         $generator->generate($this->getBundle(), 'Page', 'annotation', 'twig', $actions);
 
         $files = array(
-            'Resources/views/Page/showPage.html.twig',
+            'Resources/views/Page/show_page.html.twig',
             'Resources/views/Page/pages_list.html.twig',
         );
         foreach ($files as $file) {
@@ -78,7 +78,7 @@ class ControllerGeneratorTest extends GeneratorTest
         $strings = array(
             'public function showPageAction($id, $slug)',
             'public function getListOfPagesAction($max_count)',
-            'return $this->render(\'FooBarBundle:Page:showPage.html.twig\', array(',
+            'return $this->render(\'FooBarBundle:Page:show_page.html.twig\', array(',
             'return $this->render(\'FooBarBundle:Page:pages_list.html.twig\', array(',
         );
         foreach ($strings as $string) {


### PR DESCRIPTION
This one is to make the generated template names in snake_case like advised in the best practices.
I found that the "default" keyword is inconvenient as it made me replicate the code to generated the snake_case name so I removed it from the tests, replaced it with the real template name in the command and triggered a deprecation in the generator.
The snake_case code is from the Container class in the DI component.