### PR TITLE
Fixed CRUD index template for array and boolean

### DIFF
--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -41,11 +41,11 @@
 
             {%- elseif metadata.type in ['array'] %}
 
-                <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}{{ entity.' ~ field|replace({'_': ''}) ~ '|join(\', \') }}{% endif %}' }}</td>
+                <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}{{ ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ '|join(\', \') }}{% endif %}' }}</td>
 
             {%- elseif metadata.type in ['boolean'] %}
 
-                <td>{{ '{% if entity.' ~ field|replace({'_': ''}) ~ ' %}Yes{% else %}No{% endif %}' }}</td>
+                <td>{{ '{% if ' ~ entity_singularized ~ '.' ~ field|replace({'_': ''}) ~ ' %}Yes{% else %}No{% endif %}' }}</td>
 
             {%- else %}
 


### PR DESCRIPTION
After a Doctrine CRUD generation, the index shows an error _"Variable "entity" does not exist"_.

It seems that commits 0d37cf30184ec18d52ac5682937402575a37b833 and f69cdc59194be5dbd3825f3b89c4bb393f6fd64c were done in parallel and that some modifications for arrays and booleans were missing. 