### PR TITLE
Fixed entity object name in newAction

### DIFF
--- a/Resources/skeleton/crud/actions/new.php.twig
+++ b/Resources/skeleton/crud/actions/new.php.twig
@@ -26,7 +26,7 @@
             $em->flush();
 
             {% if 'show' in actions -%}
-                return $this->redirectToRoute('{{ route_name_prefix }}_show', array('id' => ${{ entity_class|lower }}->getId()));
+                return $this->redirectToRoute('{{ route_name_prefix }}_show', array('id' => ${{ entity_singularized }}->getId()));
             {%- else -%}
                 return $this->redirectToRoute('{{ route_name_prefix }}_index'));
             {%- endif %}


### PR DESCRIPTION
Object name in newAction was using the lowercase class name instead of singularized entity name.