### PR TITLE
Fix can't abort generate:controller

### DIFF
--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -14,6 +14,7 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Sensio\Bundle\GeneratorBundle\Generator\ControllerGenerator;
@@ -72,7 +73,7 @@ EOT
         $questionHelper = $this->getQuestionHelper();
 
         if ($input->isInteractive()) {
-            $question = new Question($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
+            $question = new ConfirmationQuestion($questionHelper->getQuestion('Do you confirm generation', 'yes', '?'), true);
             if (!$questionHelper->ask($input, $output, $question)) {
                 $output->writeln('<error>Command aborted</error>');
 


### PR DESCRIPTION
Now we can't abort controller generation.

~~~
...
You are going to generate a "AppBundle:Post" controller
using the "annotation" format for the routing and the "twig" format
for templating
Do you confirm generation [yes]? no

                         
  Controller generation  
                         

Generating the bundle code: OK

                                         
  Everything is OK! Now get to work :).  
~~~
