### PR TITLE
Console resides on bin folder

### DIFF
--- a/Resources/doc/commands/generate_doctrine_crud.rst
+++ b/Resources/doc/commands/generate_doctrine_crud.rst
@@ -20,14 +20,14 @@ actions:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:crud
+    $ php bin/console generate:doctrine:crud
 
 To deactivate the interactive mode, use the ``--no-interaction`` option, but don't
 forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post --format=annotation --with-write --no-interaction
+    $ php bin/console generate:doctrine:crud --entity=AcmeBlogBundle:Post --format=annotation --with-write --no-interaction
 
 Available Options
 -----------------
@@ -39,14 +39,14 @@ Available Options
 
     .. code-block:: bash
 
-      $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
+      $ php bin/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
 
 ``--route-prefix``
     The prefix to use for each route that identifies an action:
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --route-prefix=acme_post
+        $ php bin/console generate:doctrine:crud --route-prefix=acme_post
 
 ``--with-write``
     **allowed values**: ``yes|no`` **default**: ``no``
@@ -56,7 +56,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --with-write
+        $ php bin/console generate:doctrine:crud --with-write
 
 ``--format``
     **allowed values**: ``annotation|php|yml|xml`` **default**: ``annotation``
@@ -68,7 +68,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --format=annotation
+        $ php bin/console generate:doctrine:crud --format=annotation
 
 ``--overwrite``
     **allowed values**: ``yes|no`` **default**: ``no``
@@ -77,6 +77,6 @@ Available Options
 
     .. code-block:: bash
 
-         $ php app/console generate:doctrine:crud --overwrite
+         $ php bin/console generate:doctrine:crud --overwrite
 
 .. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html


### PR DESCRIPTION
I have updated the console commands for symfony 3 version, from now, the console resides into bin folder but in documentation its written app, which is valid for previous version.