### PR TITLE
Fix PSR-2 line length recommendations

### DIFF
--- a/Resources/skeleton/bundle/Extension.php.twig
+++ b/Resources/skeleton/bundle/Extension.php.twig
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Loader;
  * This is the class that loads and manages your bundle configuration.
 {% endblock phpdoc_class_header %}
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
  */
 {% block class_definition %}
 class {{ bundle_basename }}Extension extends Extension


### PR DESCRIPTION
Extension template is generating an inline phpdoc `@link` which exceed PSR-2 line lenght recommendation.

http://www.php-fig.org/psr/psr-2/#1-overview

> There MUST NOT be a hard limit on line length; the soft limit MUST be 120 characters; lines SHOULD be 80 characters or less.

`@link` anotation is enough imho, maybe previous text could be removed to get under recommended line length. 

 Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no