### PR TITLE
Replace app/console by bin/console

### DIFF
--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -13,14 +13,14 @@ structure:
 
 .. code-block:: bash
 
-    $ php app/console generate:bundle
+    $ php bin/console generate:bundle
 
 To deactivate the interactive mode, use the `--no-interaction` option but don't
 forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:bundle --namespace=Acme/Bundle/BlogBundle --no-interaction
+    $ php bin/console generate:bundle --namespace=Acme/Bundle/BlogBundle --no-interaction
 
 Available Options
 -----------------


### PR DESCRIPTION
Hi,
In the version 3.0 of Symfony2 the command line is php bin/console not php app/console
See the answer of this post http://stackoverflow.com/questions/34045622/could-not-open-input-file-app-console-symfony-2-in-both-mamp-and-vagrant
Best regards.