### PR TITLE
Implement quoted services references for Symfony 3

### DIFF
--- a/Resources/skeleton/bundle/services.yml.twig
+++ b/Resources/skeleton/bundle/services.yml.twig
@@ -2,5 +2,5 @@ services:
 {% block services %}
 #    {{ extension_alias }}.example:
 #        class: {{ namespace }}\Example
-#        arguments: [@service_id, "plain_value", %parameter%]
+#        arguments: ["@service_id", "plain_value", %parameter%]
 {% endblock services %}


### PR DESCRIPTION
I think by using Gherkin is the easiest to describe the scope of this pull request:

Given the symfony instance is 2.8 or upper
If the service has a dependency on another service
Then the service argument should be quoted in "
And no deprecation notice will be raised

If the generator is currently used to create a bundle on a 2.8 / 3 instance of Symfony, the services.yml file will have examples of services without quotes.

E.g:
```
services:
#    game.example:
#        class: GameBundle\Example
#        arguments: [@service_id, "plain_value", %parameter%]
```

To avoid potential troubles, I thought the example should be as I have modified it with my pull request.