### PR TITLE
Generating the tests into the root tests/ directory for non-shared bundles

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -386,8 +386,11 @@ EOT
         }
         $format = Validators::validateFormat($input->getOption('format'));
 
+        // an assumption that the kernel root dir is in a directory (like app/)
+        $projectRootDirectory = $this->getContainer()->getParameter('kernel.root_dir').'/..';
+
         if (!$this->getContainer()->get('filesystem')->isAbsolutePath($dir)) {
-            $dir = getcwd().'/'.$dir;
+            $dir = $projectRootDirectory.'/'.$dir;
         }
         // add trailing / if necessary
         $dir = '/' === substr($dir, -1, 1) ? $dir : $dir.'/';
@@ -402,7 +405,7 @@ EOT
 
         // not shared - put the tests in the root
         if (!$shared) {
-            $testsDir = getcwd().'/tests/'.$bundleName;
+            $testsDir = $projectRootDirectory.'/tests/'.$bundleName;
             $bundle->setTestsDirectory($testsDir);
         }
 

--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -392,13 +392,21 @@ EOT
         // add trailing / if necessary
         $dir = '/' === substr($dir, -1, 1) ? $dir : $dir.'/';
 
-        return new Bundle(
+        $bundle = new Bundle(
             $namespace,
             $bundleName,
             $dir,
             $format,
             $shared
         );
+
+        // not shared - put the tests in the root
+        if (!$shared) {
+            $testsDir = getcwd().'/tests/'.$bundleName;
+            $bundle->setTestsDirectory($testsDir);
+        }
+
+        return $bundle;
     }
 
     protected function createGenerator()

--- a/Generator/BundleGenerator.php
+++ b/Generator/BundleGenerator.php
@@ -59,7 +59,7 @@ class BundleGenerator extends Generator
             $this->renderFile('bundle/Configuration.php.twig', $dir.'/DependencyInjection/Configuration.php', $parameters);
         }
         $this->renderFile('bundle/DefaultController.php.twig', $dir.'/Controller/DefaultController.php', $parameters);
-        $this->renderFile('bundle/DefaultControllerTest.php.twig', $dir.'/Tests/Controller/DefaultControllerTest.php', $parameters);
+        $this->renderFile('bundle/DefaultControllerTest.php.twig', $bundle->getTestsDirectory().'/Controller/DefaultControllerTest.php', $parameters);
         $this->renderFile('bundle/index.html.twig.twig', $dir.'/Resources/views/Default/index.html.twig', $parameters);
 
         // render the services.yml/xml file

--- a/Model/Bundle.php
+++ b/Model/Bundle.php
@@ -19,6 +19,8 @@ class Bundle
 
     private $isShared;
 
+    private $testsDirectory;
+
     public function __construct($namespace, $name, $targetDirectory, $configurationFormat, $isShared)
     {
         $this->namespace = $namespace;
@@ -26,6 +28,7 @@ class Bundle
         $this->targetDirectory = $targetDirectory;
         $this->configurationFormat = $configurationFormat;
         $this->isShared = $isShared;
+        $this->testsDirectory = $this->getTargetDirectory().'/Tests';
     }
 
     public function getNamespace()
@@ -126,5 +129,15 @@ class Bundle
     public function getBundleClassName()
     {
         return $this->namespace.'\\'.$this->name;
+    }
+
+    public function setTestsDirectory($testsDirectory)
+    {
+        $this->testsDirectory = $testsDirectory;
+    }
+
+    public function getTestsDirectory()
+    {
+        return $this->testsDirectory;
     }
 }

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -24,9 +24,11 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         list($namespace, $bundleName, $dir, $format, $shared) = $expected;
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
+        $container = $this->getContainer();
+
         // not shared? the tests should be at the root of the project
         if (!$shared) {
-            $bundle->setTestsDirectory($this->kernelRootDir.'/../tests/'.$bundleName);
+            $bundle->setTestsDirectory($container->getParameter('kernel.root_dir').'/../tests/'.$bundleName);
         }
 
         $generator = $this->getGenerator();
@@ -36,7 +38,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
             ->with($bundle)
         ;
 
-        $tester = new CommandTester($this->getCommand($generator, $input));
+        $tester = new CommandTester($this->getCommand($generator, $input, $container));
         $tester->execute($options);
     }
 
@@ -80,9 +82,11 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         list($namespace, $bundleName, $dir, $format, $shared) = $expected;
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
+        $container = $this->getContainer();
+
         // not shared? the tests should be at the root of the project
         if (!$shared) {
-            $bundle->setTestsDirectory($this->kernelRootDir.'/../tests/'.$bundleName);
+            $bundle->setTestsDirectory($container->getParameter('kernel.root_dir').'/../tests/'.$bundleName);
         }
 
         $generator = $this->getGenerator();
@@ -92,7 +96,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
             ->with($bundle)
         ;
 
-        $tester = new CommandTester($this->getCommand($generator, ''));
+        $tester = new CommandTester($this->getCommand($generator, '', $container));
         $tester->execute($options, array('interactive' => false));
     }
 
@@ -116,7 +120,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         );
     }
 
-    protected function getCommand($generator, $input)
+    protected function getCommand($generator, $input, $container)
     {
         $command = $this
             ->getMockBuilder('Sensio\Bundle\GeneratorBundle\Command\GenerateBundleCommand')
@@ -124,7 +128,7 @@ class GenerateBundleCommandTest extends GenerateCommandTest
             ->getMock()
         ;
 
-        $command->setContainer($this->getContainer());
+        $command->setContainer($container);
         $command->setHelperSet($this->getHelperSet($input));
         $command->setGenerator($generator);
 

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -24,6 +24,12 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         list($namespace, $bundleName, $dir, $format, $shared) = $expected;
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
+        // not shared? the tests should be at the root of the project
+        // which, is cheaply done with getcwd
+        if (!$shared) {
+            $bundle->setTestsDirectory(getcwd().'/tests/'.$bundleName);
+        }
+
         $generator = $this->getGenerator();
         $generator
             ->expects($this->once())
@@ -74,6 +80,12 @@ class GenerateBundleCommandTest extends GenerateCommandTest
     {
         list($namespace, $bundleName, $dir, $format, $shared) = $expected;
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
+
+        // not shared? the tests should be at the root of the project
+        // which, is cheaply done with getcwd
+        if (!$shared) {
+            $bundle->setTestsDirectory(getcwd().'/tests/'.$bundleName);
+        }
 
         $generator = $this->getGenerator();
         $generator

--- a/Tests/Command/GenerateBundleCommandTest.php
+++ b/Tests/Command/GenerateBundleCommandTest.php
@@ -25,9 +25,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
         // not shared? the tests should be at the root of the project
-        // which, is cheaply done with getcwd
         if (!$shared) {
-            $bundle->setTestsDirectory(getcwd().'/tests/'.$bundleName);
+            $bundle->setTestsDirectory($this->kernelRootDir.'/../tests/'.$bundleName);
         }
 
         $generator = $this->getGenerator();
@@ -82,9 +81,8 @@ class GenerateBundleCommandTest extends GenerateCommandTest
         $bundle = new Bundle($namespace, $bundleName, $dir, $format, $shared);
 
         // not shared? the tests should be at the root of the project
-        // which, is cheaply done with getcwd
         if (!$shared) {
-            $bundle->setTestsDirectory(getcwd().'/tests/'.$bundleName);
+            $bundle->setTestsDirectory($this->kernelRootDir.'/../tests/'.$bundleName);
         }
 
         $generator = $this->getGenerator();

--- a/Tests/Command/GenerateCommandTest.php
+++ b/Tests/Command/GenerateCommandTest.php
@@ -18,13 +18,6 @@ use Symfony\Component\DependencyInjection\Container;
 
 abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 {
-    protected $kernelRootDir;
-
-    public function setup()
-    {
-        $this->kernelRootDir = sys_get_temp_dir();
-    }
-
     protected function getHelperSet($input)
     {
         $question = new QuestionHelper();
@@ -79,7 +72,7 @@ abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
         $container->set('kernel', $kernel);
         $container->set('filesystem', $filesystem);
 
-        $container->setParameter('kernel.root_dir', $this->kernelRootDir);
+        $container->setParameter('kernel.root_dir', sys_get_temp_dir());
 
         return $container;
     }

--- a/Tests/Command/GenerateCommandTest.php
+++ b/Tests/Command/GenerateCommandTest.php
@@ -18,6 +18,13 @@ use Symfony\Component\DependencyInjection\Container;
 
 abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 {
+    protected $kernelRootDir;
+
+    public function setup()
+    {
+        $this->kernelRootDir = sys_get_temp_dir();
+    }
+
     protected function getHelperSet($input)
     {
         $question = new QuestionHelper();
@@ -72,7 +79,7 @@ abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
         $container->set('kernel', $kernel);
         $container->set('filesystem', $filesystem);
 
-        $container->setParameter('kernel.root_dir', sys_get_temp_dir());
+        $container->setParameter('kernel.root_dir', $this->kernelRootDir);
 
         return $container;
     }

--- a/Tests/Generator/BundleGeneratorTest.php
+++ b/Tests/Generator/BundleGeneratorTest.php
@@ -136,6 +136,15 @@ class BundleGeneratorTest extends GeneratorTest
         $this->getGenerator()->generateBundle($bundle);
     }
 
+    public function testAlternateTestsDirectory()
+    {
+        $bundle = new Bundle('Foo\BarBundle', 'FooBarBundle', $this->tmpDir, 'xml', true);
+        $bundle->setTestsDirectory($this->tmpDir.'/other/path/tests');
+        $this->getGenerator()->generateBundle($bundle);
+
+        $this->assertTrue(file_exists($this->tmpDir.'/other/path/tests/Controller/DefaultControllerTest.php'));
+    }
+
     protected function getGenerator()
     {
         $generator = new BundleGenerator($this->filesystem);


### PR DESCRIPTION
This fixes #416 in a very sensible way:

A) If the bundle is "shared", then the tests go inside the bundle (as always)
B) If the bundle is not shared, then the tests go into `/tests` at the root of the project.

I've tested this and it works great in both cases. I *am* using `getcwd()` to find the root of the project. But this is already done in the generator to find the `src/` directory. So if we're worried about this assumption, it should be fixed later.

Thanks!