### PR TITLE
Replace getMock calls with getMockBuilder()->getMock() calls in tests

### DIFF
--- a/Tests/Command/AutoComplete/EntitiesAutoCompleterTest.php
+++ b/Tests/Command/AutoComplete/EntitiesAutoCompleterTest.php
@@ -66,14 +66,14 @@ class EntitiesAutoCompleterTest extends \PHPUnit_Framework_TestCase
      */
     protected function getEntityManagerMock($aliases, $classes)
     {
-        $cache = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $cache = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')->getMock();
         $cache
             ->expects($this->any())
             ->method('getAllClassNames')
             ->will($this->returnValue($classes))
         ;
 
-        $configuration = $this->getMock('Doctrine\ORM\Configuration');
+        $configuration = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
         $configuration
             ->expects($this->any())
             ->method('getMetadataDriverImpl')
@@ -86,7 +86,7 @@ class EntitiesAutoCompleterTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($aliases))
         ;
 
-        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')->getMock();
         $manager
             ->expects($this->any())
             ->method('getConfiguration')

--- a/Tests/Command/GenerateCommandCommandTest.php
+++ b/Tests/Command/GenerateCommandCommandTest.php
@@ -159,7 +159,7 @@ class GenerateCommandCommandTest extends GenerateCommandTest
 
     protected function setBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));

--- a/Tests/Command/GenerateCommandTest.php
+++ b/Tests/Command/GenerateCommandTest.php
@@ -28,7 +28,7 @@ abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function getBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle
             ->expects($this->any())
             ->method('getPath')
@@ -49,7 +49,7 @@ abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 
     protected function getContainer()
     {
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\KernelInterface')->getMock();
         $kernel
             ->expects($this->any())
             ->method('getBundle')
@@ -61,7 +61,7 @@ abstract class GenerateCommandTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array($this->getBundle())))
         ;
 
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
+        $filesystem = $this->getMockBuilder('Symfony\Component\Filesystem\Filesystem')->getMock();
         $filesystem
             ->expects($this->any())
             ->method('isAbsolutePath')

--- a/Tests/Command/GenerateControllerCommandTest.php
+++ b/Tests/Command/GenerateControllerCommandTest.php
@@ -196,7 +196,7 @@ class GenerateControllerCommandTest extends GenerateCommandTest
 
     protected function setBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -244,14 +244,14 @@ DATA;
 
     protected function getDoctrine()
     {
-        $cache = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $cache = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')->getMock();
         $cache
             ->expects($this->any())
             ->method('getAllClassNames')
             ->will($this->returnValue(array('Acme\Bundle\BlogBundle\Entity\Post')))
         ;
 
-        $configuration = $this->getMock('Doctrine\ORM\Configuration');
+        $configuration = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
         $configuration
             ->expects($this->any())
             ->method('getMetadataDriverImpl')
@@ -264,14 +264,14 @@ DATA;
             ->will($this->returnValue(array('AcmeBlogBundle' => 'Acme\Bundle\BlogBundle\Entity')))
         ;
 
-        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')->getMock();
         $manager
             ->expects($this->any())
             ->method('getConfiguration')
             ->will($this->returnValue($configuration))
         ;
 
-        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->getMock();
         $registry
             ->expects($this->any())
             ->method('getAliasNamespace')

--- a/Tests/Generator/CommandGeneratorTest.php
+++ b/Tests/Generator/CommandGeneratorTest.php
@@ -69,7 +69,7 @@ class CommandGeneratorTest extends GeneratorTest
 
     protected function getBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));

--- a/Tests/Generator/ControllerGeneratorTest.php
+++ b/Tests/Generator/ControllerGeneratorTest.php
@@ -129,7 +129,7 @@ class ControllerGeneratorTest extends GeneratorTest
 
     protected function getBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -224,7 +224,7 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
 
     protected function getBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));

--- a/Tests/Generator/DoctrineEntityGeneratorTest.php
+++ b/Tests/Generator/DoctrineEntityGeneratorTest.php
@@ -112,7 +112,7 @@ class DoctrineEntityGeneratorTest extends GeneratorTest
 
     protected function getBundle()
     {
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getName')->will($this->returnValue('FooBarBundle'));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));
@@ -130,7 +130,7 @@ class DoctrineEntityGeneratorTest extends GeneratorTest
 
     public function getRegistry()
     {
-        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
+        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->getMock();
         $registry->expects($this->any())->method('getManager')->will($this->returnValue($this->getManager()));
         $registry->expects($this->any())->method('getAliasNamespace')->will($this->returnValue('Foo\\BarBundle\\Entity'));
 
@@ -139,7 +139,7 @@ class DoctrineEntityGeneratorTest extends GeneratorTest
 
     public function getManager()
     {
-        $manager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $manager = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')->getMock();
         $manager->expects($this->any())
             ->method('getConfiguration')
             ->will($this->returnValue($this->getConfiguration()));
@@ -149,7 +149,7 @@ class DoctrineEntityGeneratorTest extends GeneratorTest
 
     public function getConfiguration()
     {
-        $config = $this->getMock('Doctrine\ORM\Configuration');
+        $config = $this->getMockBuilder('Doctrine\ORM\Configuration')->getMock();
         $config->expects($this->any())->method('getEntityNamespaces')->will($this->returnValue(array('Foo\\BarBundle')));
 
         return $config;

--- a/Tests/Generator/DoctrineFormGeneratorTest.php
+++ b/Tests/Generator/DoctrineFormGeneratorTest.php
@@ -61,7 +61,7 @@ class DoctrineFormGeneratorTest extends GeneratorTest
         $generator = new DoctrineFormGenerator($this->filesystem);
         $generator->setSkeletonDirs(__DIR__.'/../../Resources/skeleton');
 
-        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\BundleInterface')->getMock();
         $bundle->expects($this->any())->method('getPath')->will($this->returnValue($this->tmpDir));
         $bundle->expects($this->any())->method('getNamespace')->will($this->returnValue('Foo\BarBundle'));
 


### PR DESCRIPTION
The upgrade to PHPUnit 5.4 wants us to use `createMock` instead of `getMock` as per [the PHPUnit 5.4 Releasenotes](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0#changes).

This PR changes the tests so they execute properly using the latest PHPUnit.