### PR TITLE
Add bundles name auto-completion.

### DIFF
--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -85,12 +85,12 @@ EOT
                 '',
             ));
 
+            $bundleNames = array_keys($this->getContainer()->get('kernel')->getBundles());
+
             $question = new Question($questionHelper->getQuestion('Bundle name', $bundle), $bundle);
-            $container = $this->getContainer();
-            $question->setValidator(function ($answer) use ($container) {
-                try {
-                   $b = $container->get('kernel')->getBundle($answer);
-                } catch (\Exception $e) {
+            $question->setAutocompleterValues($bundleNames);
+            $question->setValidator(function ($answer) use ($bundleNames) {
+                if (!in_array($answer, $bundleNames)) {
                     throw new \RuntimeException(sprintf('Bundle "%s" does not exist.', $answer));
                 }
 

--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -122,8 +122,11 @@ EOT
             '',
         ));
 
+        $bundleNames = array_keys($this->getContainer()->get('kernel')->getBundles());
+
         while (true) {
             $question = new Question($questionHelper->getQuestion('Controller name', $input->getOption('controller')), $input->getOption('controller'));
+            $question->setAutocompleterValues($bundleNames);
             $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateControllerName'));
             $controller = $questionHelper->ask($input, $output, $question);
             list($bundle, $controller) = $this->parseShortcutNotation($controller);


### PR DESCRIPTION
This adds the auto-completion of bundles name in the `generate:controller` and the `generate:command` commands.
This is only a lousy copy-pasting of the auto-completion made in the `generate:doctrine:crud` command.