### PR TITLE
Fix for Undefined variable: actionName error

### DIFF
--- a/Generator/ControllerGenerator.php
+++ b/Generator/ControllerGenerator.php
@@ -62,7 +62,7 @@ class ControllerGenerator extends Generator
             if ('default' == $template) {
                 @trigger_error('The use of the "default" keyword is deprecated. Use the real template name instead.', E_USER_DEPRECATED);
                 $template = $bundle->getName().':'.$controller.':'.
-                    strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr(substr($actionName, 0, -6), '_', '.')))
+                    strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr(substr($action['name'], 0, -6), '_', '.')))
                     .'.html.'.$templateFormat;
             }
 


### PR DESCRIPTION
Using generator with actions option fails

```sh
php bin/console generate:controller -v --controller=SomeBundle:Entity --actions="showAction:/path"
```

![image](https://cloud.githubusercontent.com/assets/238022/18028796/398da2f6-6c55-11e6-967c-482a8ee95bab.png)

[Symfony\Component\Debug\Exception\ContextErrorException]
  Notice: Undefined variable: actionName