### PR TITLE
Fixed entity variable name in crud generator

### DIFF
--- a/Generator/DoctrineCrudGenerator.php
+++ b/Generator/DoctrineCrudGenerator.php
@@ -69,15 +69,18 @@ class DoctrineCrudGenerator extends Generator
         }
 
         $this->entity = $entity;
-        $this->entitySingularized = lcfirst(Inflector::singularize($entity));
-        $this->entityPluralized = lcfirst(Inflector::pluralize($entity));
+        $entity = str_replace('\\', '/', $entity);
+        $entityParts = explode('/', $entity);
+        $entityName = end($entityParts);
+        $this->entitySingularized = lcfirst(Inflector::singularize($entityName));
+        $this->entityPluralized = lcfirst(Inflector::pluralize($entityName));
         $this->bundle = $bundle;
         $this->metadata = $metadata;
         $this->setFormat($format);
 
         $this->generateControllerClass($forceOverwrite);
 
-        $dir = sprintf('%s/Resources/views/%s', $this->rootDir, str_replace('\\', '/', strtolower($this->entity)));
+        $dir = sprintf('%s/Resources/views/%s', $this->rootDir, strtolower($entity));
 
         if (!file_exists($dir)) {
             $this->filesystem->mkdir($dir, 0777);

--- a/Resources/skeleton/crud/actions/delete.php.twig
+++ b/Resources/skeleton/crud/actions/delete.php.twig
@@ -1,7 +1,7 @@
 
     /**
 {% block phpdoc_method_header %}
-     * Deletes a {{ entity }} entity.
+     * Deletes a {{ entity_singularized }} entity.
 {% endblock phpdoc_method_header %}
      *
 {% block phpdoc_method_annotations %}
@@ -33,9 +33,9 @@
 
 {% block form %}
     /**
-     * Creates a form to delete a {{ entity }} entity.
+     * Creates a form to delete a {{ entity_singularized }} entity.
      *
-     * @param {{ entity_class }} ${{ entity_singularized }} The {{ entity }} entity
+     * @param {{ entity_class }} ${{ entity_singularized }} The {{ entity_singularized }} entity
      *
      * @return \Symfony\Component\Form\Form The form
      */

--- a/Resources/skeleton/crud/actions/edit.php.twig
+++ b/Resources/skeleton/crud/actions/edit.php.twig
@@ -1,7 +1,7 @@
 
     /**
 {% block phpdoc_method_header %}
-     * Displays a form to edit an existing {{ entity }} entity.
+     * Displays a form to edit an existing {{ entity_singularized }} entity.
 {% endblock phpdoc_method_header %}
      *
 {% block phpdoc_method_annotations %}
@@ -17,7 +17,7 @@
     {
 {% block method_body %}
         $deleteForm = $this->createDeleteForm(${{ entity_singularized }});
-        $editForm = $this->createForm('{{ namespace }}\Form\{{ entity_class }}Type', ${{ entity_singularized }});
+        $editForm = $this->createForm('{{ namespace }}\Form\{{ entity }}Type', ${{ entity_singularized }});
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {

--- a/Resources/skeleton/crud/actions/index.php.twig
+++ b/Resources/skeleton/crud/actions/index.php.twig
@@ -1,6 +1,6 @@
     /**
 {% block phpdoc_method_header %}
-     * Lists all {{ entity }} entities.
+     * Lists all {{ entity_singularized }} entities.
 {% endblock phpdoc_method_header %}
      *
 {% block phpdoc_method_annotations %}

--- a/Resources/skeleton/crud/actions/new.php.twig
+++ b/Resources/skeleton/crud/actions/new.php.twig
@@ -16,7 +16,7 @@
 {% endblock method_definition %}
     {
 {% block method_body %}
-        $form = $this->createForm('{{ namespace }}\Form\{{ entity_class }}Type', ${{ entity_singularized }});
+        $form = $this->createForm('{{ namespace }}\Form\{{ entity }}Type');
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/Resources/skeleton/crud/actions/show.php.twig
+++ b/Resources/skeleton/crud/actions/show.php.twig
@@ -1,7 +1,7 @@
 
     /**
 {% block phpdoc_method_header %}
-     * Finds and displays a {{ entity }} entity.
+     * Finds and displays a {{ entity_singularized }} entity.
 {% endblock phpdoc_method_header %}
      *
 {% block phpdoc_method_annotations %}

--- a/Resources/skeleton/crud/controller.php.twig
+++ b/Resources/skeleton/crud/controller.php.twig
@@ -21,7 +21,7 @@ use {{ namespace }}\Form\{{ entity }}Type;
 
 /**
 {% block phpdoc_class_header %}
- * {{ entity }} controller.
+ * {{ entity_singularized|capitalize }} controller.
 {% endblock phpdoc_class_header %}
  *
 {% block phpdoc_class_annotations %}

--- a/Resources/skeleton/crud/views/edit.html.twig.twig
+++ b/Resources/skeleton/crud/views/edit.html.twig.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 {{ "{% block body %}" }}
-    <h1>{{ entity }} edit</h1>
+    <h1>{{ entity_singularized|capitalize }} edit</h1>
 
     {{ '{{ form_start(edit_form) }}' }}
         {{ '{{ form_widget(edit_form) }}' }}

--- a/Resources/skeleton/crud/views/index.html.twig.twig
+++ b/Resources/skeleton/crud/views/index.html.twig.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 {{ "{% block body %}" }}
-    <h1>{{ entity }} list</h1>
+    <h1>{{ entity_pluralized|capitalize }} list</h1>
 
     <table>
         <thead>
@@ -80,7 +80,7 @@
     {% if 'new' in actions -%}
     <ul>
         <li>
-            <a href="{{ "{{ path('" ~ route_name_prefix ~ "_new') }}" }}">Create a new entry</a>
+            <a href="{{ "{{ path('" ~ route_name_prefix ~ "_new') }}" }}">Create a new {{ entity_singularized }}</a>
         </li>
     </ul>
     {%- endif %}

--- a/Resources/skeleton/crud/views/new.html.twig.twig
+++ b/Resources/skeleton/crud/views/new.html.twig.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 {{ "{% block body %}" }}
-    <h1>{{ entity }} creation</h1>
+    <h1>{{ entity_singularized|capitalize }} creation</h1>
 
     {{ '{{ form_start(form) }}' }}
         {{ '{{ form_widget(form) }}' }}

--- a/Resources/skeleton/crud/views/show.html.twig.twig
+++ b/Resources/skeleton/crud/views/show.html.twig.twig
@@ -4,7 +4,7 @@
 
 {% block body %}
 {{ "{% block body %}" }}
-    <h1>{{ entity }}</h1>
+    <h1>{{ entity_singularized|capitalize }}</h1>
 
     <table>
         <tbody>

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -180,6 +180,36 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         }
     }
 
+    public function testGenerateNamespacedEntity()
+    {
+        $this->getGenerator()->generate($this->getBundle(), 'Blog\Post', $this->getMetadata(), 'annotation', '/blog_post', true, true);
+
+        $files = array(
+            'Controller/Blog/PostController.php',
+            'Tests/Controller/Blog/PostControllerTest.php',
+            'Resources/views/blog/post/index.html.twig',
+            'Resources/views/blog/post/show.html.twig',
+            'Resources/views/blog/post/new.html.twig',
+            'Resources/views/blog/post/edit.html.twig',
+        );
+        foreach ($files as $file) {
+            $this->assertTrue(file_exists($this->tmpDir.'/'.$file), sprintf('%s has been generated', $file));
+        }
+
+        $content = file_get_contents($this->tmpDir.'/Controller/Blog/PostController.php');
+        $strings = array(
+            'namespace Foo\BarBundle\Controller\Blog;',
+            'public function showAction(Post $post)',
+            '\'post\' => $post,',
+            '\'posts\' => $posts,',
+            '$form = $this->createForm(\'Foo\BarBundle\Form\Blog\PostType\');',
+            '$editForm = $this->createForm(\'Foo\BarBundle\Form\Blog\PostType\', $post);',
+        );
+        foreach ($strings as $string) {
+            $this->assertContains($string, $content);
+        }
+    }
+
     /**
      * @dataProvider getRoutePrefixes
      */


### PR DESCRIPTION
Closes #478.

Fixes the entity name in controller methods and templates when the entity is in a sub namespace (e.g `MyBundle\Entity\Blog\Post`.