### PR TITLE
[DX] Normalized entity argument for doctrine commands

### DIFF
--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -43,24 +43,22 @@ class GenerateDoctrineCrudCommand extends GenerateDoctrineCommand
             ->setName('doctrine:generate:crud')
             ->setAliases(array('generate:doctrine:crud'))
             ->setDescription('Generates a CRUD based on a Doctrine entity')
-            ->setDefinition(array(
-                new InputArgument('entity', InputArgument::OPTIONAL, 'The entity class name to initialize (shortcut notation)'),
-                new InputOption('entity', '', InputOption::VALUE_REQUIRED, 'The entity class name to initialize (shortcut notation)'),
-                new InputOption('route-prefix', '', InputOption::VALUE_REQUIRED, 'The route prefix'),
-                new InputOption('with-write', '', InputOption::VALUE_NONE, 'Whether or not to generate create, new and delete actions'),
-                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The format used for configuration files (php, xml, yml, or annotation)', 'annotation'),
-                new InputOption('overwrite', '', InputOption::VALUE_NONE, 'Overwrite any existing controller or form class when generating the CRUD contents'),
-            ))
+            ->addArgument('entity', InputArgument::OPTIONAL, 'The entity class name to initialize (shortcut notation)')
+            ->addOption('entity', null, InputOption::VALUE_OPTIONAL, 'The entity class name to initialize (shortcut notation)')
+            ->addOption('route-prefix', null, InputOption::VALUE_REQUIRED, 'The route prefix')
+            ->addOption('with-write', null, InputOption::VALUE_NONE, 'Whether or not to generate create, new and delete actions')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The format used for configuration files (php, xml, yml, or annotation)', 'annotation')
+            ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Overwrite any existing controller or form class when generating the CRUD contents')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command generates a CRUD based on a Doctrine entity.
 
 The default command only generates the list and show actions.
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Post --route-prefix=post_admin</info>
+<info>php %command.full_name% AcmeBlogBundle:Post --route-prefix=post_admin</info>
 
 Using the --with-write option allows to generate the new, edit and delete actions.
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Post --route-prefix=post_admin --with-write</info>
+<info>php %command.full_name% AcmeBlogBundle:Post --route-prefix=post_admin --with-write</info>
 
 Every generated file is based on a template. There are default templates but they can be overridden by placing custom templates in one of the following locations, by order of priority:
 
@@ -93,9 +91,16 @@ EOT
 
                 return 1;
             }
+        } else {
+            // BC to be removed in 4.0
+            if ($input->hasOption('entity') && $entityOption = $input->getOption('entity')) {
+                @trigger_error('Using the "--entity" option has been deprecated since version 3.0 and will be removed in 4.0. Pass it as argument instead.', E_USER_DEPRECATED);
+
+                $input->setArgument('entity', $entityOption);
+            }
         }
 
-        $entity = Validators::validateEntityName($input->getOption('entity'));
+        $entity = Validators::validateEntityName($input->getArgument('entity'));
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
         $format = Validators::validateFormat($input->getOption('format'));
@@ -154,11 +159,13 @@ EOT
             '',
         ));
 
-        if ($input->hasArgument('entity') && $input->getArgument('entity') != '') {
-            $input->setOption('entity', $input->getArgument('entity'));
+        if ($input->hasOption('entity') && $entityOption = $input->getOption('entity')) {
+            @trigger_error('Using the "--entity" option has been deprecated since version 3.0 and will be removed in 4.0. Pass it as argument instead.', E_USER_DEPRECATED);
+
+            $input->setArgument('entity', $entityOption);
         }
 
-        $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getOption('entity')), $input->getOption('entity'));
+        $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getArgument('entity')), $input->getArgument('entity'));
         $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'));
 
         $autocompleter = new EntitiesAutoCompleter($this->getContainer()->get('doctrine')->getManager());
@@ -166,7 +173,7 @@ EOT
         $question->setAutocompleterValues($autocompleteEntities);
         $entity = $questionHelper->ask($input, $output, $question);
 
-        $input->setOption('entity', $entity);
+        $input->setArgument('entity', $entity);
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
         try {

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -13,6 +13,7 @@ namespace Sensio\Bundle\GeneratorBundle\Command;
 
 use Sensio\Bundle\GeneratorBundle\Generator\DoctrineEntityGenerator;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,14 +34,15 @@ class GenerateDoctrineEntityCommand extends GenerateDoctrineCommand
             ->setName('doctrine:generate:entity')
             ->setAliases(array('generate:doctrine:entity'))
             ->setDescription('Generates a new Doctrine entity inside a bundle')
-            ->addOption('entity', null, InputOption::VALUE_REQUIRED, 'The entity class name to initialize (shortcut notation)')
+            ->addArgument('entity', InputArgument::OPTIONAL, 'The entity class name to initialize (shortcut notation)')
+            ->addOption('entity', null, InputOption::VALUE_OPTIONAL, 'The entity class name to initialize (shortcut notation)')
             ->addOption('fields', null, InputOption::VALUE_REQUIRED, 'The fields to create with the new entity')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Use the format for configuration files (php, xml, yml, or annotation)', 'annotation')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> task generates a new Doctrine
 entity inside a bundle:
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post</info>
+<info>php %command.full_name% AcmeBlogBundle:Blog/Post</info>
 
 The above command would initialize a new entity in the following entity
 namespace <info>Acme\BlogBundle\Entity\Blog\Post</info>.
@@ -48,21 +50,21 @@ namespace <info>Acme\BlogBundle\Entity\Blog\Post</info>.
 You can also optionally specify the fields you want to generate in the new
 entity:
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --fields="title:string(255) body:text"</info>
+<info>php %command.full_name% AcmeBlogBundle:Blog/Post --fields="title:string(255) body:text"</info>
 
 By default, the command uses annotations for the mapping information; change it
 with <comment>--format</comment>:
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=yml</info>
+<info>php %command.full_name% AcmeBlogBundle:Blog/Post --format=yml</info>
 
-To deactivate the interaction mode, simply use the <comment>--no-interaction</comment> option
-without forgetting to pass all needed options:
+To deactivate the interaction mode, simply use the <comment>--no-interaction</comment> option or its
+alias <comment>-n</comment>, without forgetting to pass all needed options:
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(255) body:text" --no-interaction</info>
+<info>php %command.full_name% AcmeBlogBundle:Blog/Post -n --format=annotation --fields="title:string(255) body:text"</info>
 
 This also has support for passing field specific attributes:
 
-<info>php %command.full_name% --entity=AcmeBlogBundle:Blog/Post --format=annotation --fields="title:string(length=255 nullable=true unique=true) body:text ranking:decimal(precision:10 scale:0)" --no-interaction</info>
+<info>php %command.full_name% AcmeBlogBundle:Blog/Post -n --format=annotation --fields="title:string(length=255 nullable=true unique=true) body:text ranking:decimal(precision:10 scale:0)"</info>
 EOT
         );
     }
@@ -74,7 +76,14 @@ EOT
     {
         $questionHelper = $this->getQuestionHelper();
 
-        $entity = Validators::validateEntityName($input->getOption('entity'));
+        // BC to be removed in 4.0
+        if (!$input->isInteractive() && $input->hasOption('entity') && $entityOption = $input->getOption('entity')) {
+            @trigger_error('Using the "--entity" option has been deprecated since version 3.0 and will be removed in 4.0. Pass it as argument instead.', E_USER_DEPRECATED);
+
+            $input->setArgument('entity', $entityOption);
+        }
+
+        $entity = Validators::validateEntityName($input->getArgument('entity'));
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
         $format = Validators::validateFormat($input->getOption('format'));
         $fields = $this->parseFields($input->getOption('fields'));
@@ -120,10 +129,16 @@ EOT
             '',
         ));
 
+        if ($input->hasOption('entity') && $entityOption = $input->getOption('entity')) {
+            @trigger_error('Using the "--entity" option has been deprecated since version 3.0 and will be removed in 4.0. Pass it as argument instead.', E_USER_DEPRECATED);
+
+            $input->setArgument('entity', $entityOption);
+        }
+
         $bundleNames = array_keys($this->getContainer()->get('kernel')->getBundles());
 
         while (true) {
-            $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getOption('entity')), $input->getOption('entity'));
+            $question = new Question($questionHelper->getQuestion('The Entity shortcut name', $input->getArgument('entity')), $input->getArgument('entity'));
             $question->setValidator(array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'));
             $question->setAutocompleterValues($bundleNames);
             $entity = $questionHelper->ask($input, $output, $question);
@@ -148,7 +163,7 @@ EOT
                 $output->writeln(sprintf('<bg=red>Bundle "%s" does not exist.</>', $bundle));
             }
         }
-        $input->setOption('entity', $bundle.':'.$entity);
+        $input->setArgument('entity', $bundle.':'.$entity);
 
         // format
         $output->writeln(array(

--- a/Resources/doc/commands/generate_doctrine_crud.rst
+++ b/Resources/doc/commands/generate_doctrine_crud.rst
@@ -28,24 +28,42 @@ actions:
 
     $ php app/console generate:doctrine:crud
 
-To deactivate the interactive mode, use the ``--no-interaction`` option, but don't
-forget to pass all needed options:
+To deactivate the interactive mode, use the ``--no-interaction`` option or its
+alias ``-n``, but don't forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post --format=annotation --with-write --no-interaction
+    $ php app/console generate:doctrine:crud AcmeBlogBundle:Post -n --format=annotation --with-write
 
-Available Options
------------------
+Arguments
+---------
 
-``--entity``
+``entity``
     The entity name given in shortcut notation containing the bundle name
     in which the entity is located and the name of the entity (for example,
     ``AcmeBlogBundle:Post``):
 
     .. code-block:: bash
 
-      $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
+        $ php app/console generate:doctrine:crud AcmeBlogBundle:Post
+
+Available Options
+-----------------
+
+``--entity``
+
+    .. caution::
+
+        This option has been deprecated in version 3.0, and will be removed in 4.0.
+        Pass it as argument instead.
+
+    The entity name given in shortcut notation containing the bundle name
+    in which the entity is located and the name of the entity (for example,
+    ``AcmeBlogBundle:Post``):
+
+    .. code-block:: bash
+
+        $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
 
 ``--route-prefix``
     The prefix to use for each route that identifies an action:

--- a/Resources/doc/commands/generate_doctrine_entity.rst
+++ b/Resources/doc/commands/generate_doctrine_entity.rst
@@ -20,17 +20,35 @@ determine the bundle name, location, configuration format and default structure:
 
     $ php app/console generate:doctrine:entity
 
-The command can be run in a non-interactive mode by using the ``--no-interaction``
-option, but don't forget to pass all needed options:
+To deactivate the interactive mode, use the ``--no-interaction`` option or its
+alias ``-n``, but don't forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:entity --no-interaction --entity=AcmeBlogBundle:Post --fields="title:string(100) body:text" --format=xml
+    $ php app/console generate:doctrine:entity AcmeBlogBundle:Post -n --fields="title:string(100) body:text" --format=xml
+
+Arguments
+---------
+
+``entity``
+    The entity name given as a shortcut notation containing the bundle name
+    in which the entity is located and the name of the entity (for example,
+    ``AcmeBlogBundle:Post``):
+
+    .. code-block:: bash
+
+        $ php app/console generate:doctrine:entity AcmeBlogBundle:Post
 
 Available Options
 -----------------
 
 ``--entity``
+
+    .. caution::
+
+        This option has been deprecated in version 3.0, and will be removed in 4.0.
+        Pass it as argument instead.
+
     The entity name given as a shortcut notation containing the bundle name
     in which the entity is located and the name of the entity (for example,
     ``AcmeBlogBundle:Post``):

--- a/Tests/Command/GenerateDoctrineCrudCommandTest.php
+++ b/Tests/Command/GenerateDoctrineCrudCommandTest.php
@@ -37,11 +37,15 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
     {
         return array(
             array(array(), "AcmeBlogBundle:Blog/Post\n", array('Blog\\Post', 'annotation', 'blog_post', false)),
-            array(array('--entity' => 'AcmeBlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', 'blog_post', false)),
             array(array(), "AcmeBlogBundle:Blog/Post\ny\nyml\nfoobar\n", array('Blog\\Post', 'yml', 'foobar', true)),
             array(array(), "AcmeBlogBundle:Blog/Post\ny\nyml\n/foobar\n", array('Blog\\Post', 'yml', 'foobar', true)),
-            array(array('--entity' => 'AcmeBlogBundle:Blog/Post', '--format' => 'yml', '--route-prefix' => 'foo', '--with-write' => true), '', array('Blog\\Post', 'yml', 'foo', true)),
             array(array('entity' => 'AcmeBlogBundle:Blog/Post'), "\ny\nyml\nfoobar\n", array('Blog\\Post', 'yml', 'foobar', true)),
+            array(array('entity' => 'AcmeBlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', 'blog_post', false)),
+            array(array('entity' => 'AcmeBlogBundle:Blog/Post', '--format' => 'yml', '--route-prefix' => 'foo', '--with-write' => true), '', array('Blog\\Post', 'yml', 'foo', true)),
+            // Deprecated, to be removed in 4.0
+            array(array('--entity' => 'AcmeBlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', 'blog_post', false)),
+            array(array('--entity' => 'AcmeBlogBundle:Blog/Post', '--format' => 'yml', '--route-prefix' => 'foo', '--with-write' => true), '', array('Blog\\Post', 'yml', 'foo', true)),
+
         );
     }
 
@@ -66,6 +70,9 @@ class GenerateDoctrineCrudCommandTest extends GenerateCommandTest
     public function getNonInteractiveCommandData()
     {
         return array(
+            array(array('entity' => 'AcmeBlogBundle:Blog/Post'), array('Blog\\Post', 'annotation', 'blog_post', false)),
+            array(array('entity' => 'AcmeBlogBundle:Blog/Post', '--format' => 'yml', '--route-prefix' => 'foo', '--with-write' => true), array('Blog\\Post', 'yml', 'foo', true)),
+            // Deprecated, to be removed in 4.0
             array(array('--entity' => 'AcmeBlogBundle:Blog/Post'), array('Blog\\Post', 'annotation', 'blog_post', false)),
             array(array('--entity' => 'AcmeBlogBundle:Blog/Post', '--format' => 'yml', '--route-prefix' => 'foo', '--with-write' => true), array('Blog\\Post', 'yml', 'foo', true)),
         );

--- a/Tests/Command/GenerateDoctrineEntityCommandTest.php
+++ b/Tests/Command/GenerateDoctrineEntityCommandTest.php
@@ -40,7 +40,7 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
     {
         return array(
             array(array(), "Acme2BlogBundle:Blog/Post\n", array('Blog\\Post', 'annotation', array())),
-            array(array('--entity' => 'Acme2BlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', array())),
+            array(array('entity' => 'Acme2BlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', array())),
             array(array(), "Acme2BlogBundle:Blog/Post\nyml\n\n", array('Blog\\Post', 'yml', array())),
             array(array(), "Acme2BlogBundle:Blog/Post\nyml\ncreated_by\n\n255\nfalse\nfalse\ndescription\ntext\nfalse\ntrue\nupdated_at\ndatetime\ntrue\nfalse\nrating\ndecimal\n5\n3\nfalse\nfalse\n\n", array('Blog\\Post', 'yml', array(
                 array('fieldName' => 'createdBy', 'type' => 'string', 'length' => 255, 'columnName' => 'created_by'),
@@ -48,6 +48,8 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
                 array('fieldName' => 'updatedAt', 'type' => 'datetimetz', 'nullable' => true, 'columnName' => 'updated_at'),
                 array('fieldName' => 'rating', 'type' => 'decimal', 'precision' => 5, 'scale' => 3, 'columnName' => 'rating'),
             ))),
+            // Deprecated, to be removed in 4.0
+            array(array('--entity' => 'Acme2BlogBundle:Blog/Post'), '', array('Blog\\Post', 'annotation', array())),
         );
     }
 
@@ -78,6 +80,14 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
     public function getNonInteractiveCommandData()
     {
         return array(
+            array(array('entity' => 'Acme2BlogBundle:Blog/Post'), array('Blog\\Post', 'annotation', array())),
+            array(array('entity' => 'Acme2BlogBundle:Blog/Post', '--format' => 'yml', '--fields' => 'created_by:string(255) updated_by:string(length=128 nullable=true) description:text rating:decimal(precision=7 scale=2)'), array('Blog\\Post', 'yml', array(
+                array('fieldName' => 'created_by', 'type' => 'string', 'length' => 255),
+                array('fieldName' => 'updated_by', 'type' => 'string', 'length' => 128, 'nullable' => true),
+                array('fieldName' => 'description', 'type' => 'text'),
+                array('fieldName' => 'rating', 'type' => 'decimal', 'precision' => 7, 'scale' => 2),
+            ))),
+            // Deprecated, to be removed in 4.0
             array(array('--entity' => 'Acme2BlogBundle:Blog/Post'), array('Blog\\Post', 'annotation', array())),
             array(array('--entity' => 'Acme2BlogBundle:Blog/Post', '--format' => 'yml', '--fields' => 'created_by:string(255) updated_by:string(length=128 nullable=true) description:text rating:decimal(precision=7 scale=2)'), array('Blog\\Post', 'yml', array(
                 array('fieldName' => 'created_by', 'type' => 'string', 'length' => 255),


### PR DESCRIPTION
Follows up #280 and #286.

This was never documented. I suggest to deprecate the option as it is more verbose, and currently the only way for the form generation.
