### PR TITLE
Fix a forgotten string format

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -350,7 +350,7 @@ EOT
             $manipulator->addResource($bundle);
         } catch (\RuntimeException $e) {
             return array(
-                '- Import the bundle\'s %s resource in the app\'s main configuration file:',
+                sprintf('- Import the bundle\'s %s resource in the app\'s main configuration file:', $bundle->getServicesConfigurationFilename()),
                 '',
                 $manipulator->getImportCode($bundle),
                 '',


### PR DESCRIPTION
This is a simple bugfix, avoid a raw "%s" appearing in the terminal when this RuntimeException is thrown.