### PR TITLE
Removed excesive space at the end of the line.

### DIFF
--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -24,8 +24,7 @@ class {{ form_class }} extends AbstractType
 
                 ->add('{{ field }}')
 
-            {%- endfor %}
-        ;
+            {%- endfor %};
     }
     {% endif %}
 


### PR DESCRIPTION
When a Form is generated it shows a large space between the $builder->add line and the `;` at the end.

The code generated is:
```
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder->add('username')->add('password')        ;
    }
```

With the fix: 
```
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder->add('username')->add('password');
    }
```
