### PR TITLE
Correction on plural name entitiy

### DIFF
--- a/Resources/skeleton/crud/actions/new.php.twig
+++ b/Resources/skeleton/crud/actions/new.php.twig
@@ -16,7 +16,7 @@
 {% endblock method_definition %}
     {
 {% block method_body %}
-        ${{ entity_singularized }} = new {{ entity_singularized|capitalize }}();
+        ${{ entity_singularized }} = new {{ entity }}();
         {% if use_form_type_instance -%}
             $form = $this->createForm(new {{ entity_singularized|capitalize }}Type(), ${{ entity_singularized }});
         {% else -%}


### PR DESCRIPTION
Because is a Bug with the entity name when i used a plural.  

Because, dont make the name class correctly. 

BUG: $tipoPersona = new Tipopersona();

CORRECT: $tipoPersona = new TipoPersona();

https://github.com/sensiolabs/SensioGeneratorBundle/issues/548