### PR TITLE
change to bin/console

### DIFF
--- a/Resources/doc/commands/generate_doctrine_entity.rst
+++ b/Resources/doc/commands/generate_doctrine_entity.rst
@@ -3,7 +3,7 @@ Generating a New Doctrine Entity Stub
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php app/console`` by
+    If your application is based on Symfony 3, replace ``php bin/console`` by
     ``php bin/console`` before executing any of the console commands included
     in this article.
 
@@ -18,14 +18,14 @@ determine the bundle name, location, configuration format and default structure:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:entity
+    $ php bin/console generate:doctrine:entity
 
 The command can be run in a non-interactive mode by using the ``--no-interaction``
 option, but don't forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:entity --no-interaction --entity=AcmeBlogBundle:Post --fields="title:string(100) body:text" --format=xml
+    $ php bin/console generate:doctrine:entity --no-interaction --entity=AcmeBlogBundle:Post --fields="title:string(100) body:text" --format=xml
 
 Available Options
 -----------------
@@ -37,14 +37,14 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:entity --entity=AcmeBlogBundle:Post
+        $ php bin/console generate:doctrine:entity --entity=AcmeBlogBundle:Post
 
 ``--fields``
     The list of fields to generate in the entity class:
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:entity --fields="title:string(length=100 nullable=true unique=false) body:text ranking:decimal(precision=10 scale=0)"
+        $ php bin/console generate:doctrine:entity --fields="title:string(length=100 nullable=true unique=false) body:text ranking:decimal(precision=10 scale=0)"
 
     .. versionadded:: 3.0
         Ability to pass named options to fields was added in version 3.0.
@@ -61,4 +61,4 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:entity --format=annotation
+        $ php bin/console generate:doctrine:entity --format=annotation

--- a/Resources/doc/commands/generate_doctrine_entity.rst
+++ b/Resources/doc/commands/generate_doctrine_entity.rst
@@ -3,8 +3,8 @@ Generating a New Doctrine Entity Stub
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php bin/console`` by
-    ``php bin/console`` before executing any of the console commands included
+    If your application is based on Symfony 2, replace ``php bin/console`` by
+    ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage


### PR DESCRIPTION
symfony 3 uses `bin/console` instead of `app/console`. It is stated in the caution box but since this doc is for symfony 3.x we should show the `bin/console` in the examples instead of the old way.