### PR TITLE
Make generate:bundle report errors again

### DIFF
--- a/Command/GenerateBundleCommand.php
+++ b/Command/GenerateBundleCommand.php
@@ -91,19 +91,20 @@ EOT
         $generator->generateBundle($bundle);
 
         $errors = array();
+        $runner = $questionHelper->getRunner($output, $errors);
 
         // check that the namespace is already autoloaded
-        $this->checkAutoloader($output, $bundle);
+        $runner($this->checkAutoloader($output, $bundle));
 
         // register the bundle in the Kernel class
-        $this->updateKernel($output, $this->getContainer()->get('kernel'), $bundle);
+        $runner($this->updateKernel($output, $this->getContainer()->get('kernel'), $bundle));
 
         // routing importing
-        $this->updateRouting($output, $bundle);
+        $runner($this->updateRouting($output, $bundle));
 
         if (!$bundle->shouldGenerateDependencyInjectionDirectory()) {
             // we need to import their services.yml manually!
-            $this->updateConfiguration($output, $bundle);
+            $runner($this->updateConfiguration($output, $bundle));
         }
 
         $questionHelper->writeGeneratorSummary($output, $errors);


### PR DESCRIPTION
Simply revert a regression in #397 after which errors returned by sub-calls were ignored.
fixes #558