### PR TITLE
Invert "app/console" <-> "bin/console" (2.x <-> 3)

### DIFF
--- a/Resources/doc/commands/generate_bundle.rst
+++ b/Resources/doc/commands/generate_bundle.rst
@@ -3,8 +3,8 @@ Generating a New Bundle Skeleton
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php app/console`` by
-    ``php bin/console`` before executing any of the console commands included
+    If your application is based on Symfony 2.x version, replace ``php bin/console``
+    with ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage
@@ -19,14 +19,14 @@ structure:
 
 .. code-block:: bash
 
-    $ php app/console generate:bundle
+    $ php bin/console generate:bundle
 
 To deactivate the interactive mode, use the `--no-interaction` option but don't
 forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:bundle --namespace=Acme/Bundle/BlogBundle --no-interaction
+    $ php bin/console generate:bundle --namespace=Acme/Bundle/BlogBundle --no-interaction
 
 .. caution::
 
@@ -61,7 +61,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:bundle --namespace=Acme/Bundle/BlogBundle
+        $ php bin/console generate:bundle --namespace=Acme/Bundle/BlogBundle
 
 ``--bundle-name``
     The optional bundle name. It must be a string ending with the ``Bundle``
@@ -69,7 +69,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:bundle --bundle-name=AcmeBlogBundle
+        $ php bin/console generate:bundle --bundle-name=AcmeBlogBundle
 
 ``--dir``
     The directory in which to store the bundle. By convention, the command
@@ -77,7 +77,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:bundle --dir=/var/www/myproject/src
+        $ php bin/console generate:bundle --dir=/var/www/myproject/src
 
 ``--format``
     **allowed values**: ``annotation|php|yml|xml`` **default**: ``annotation``
@@ -89,6 +89,6 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:bundle --format=annotation
+        $ php bin/console generate:bundle --format=annotation
 
 .. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html

--- a/Resources/doc/commands/generate_command.rst
+++ b/Resources/doc/commands/generate_command.rst
@@ -3,8 +3,8 @@ Generating a New Command
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php app/console`` by
-    ``php bin/console`` before executing any of the console commands included
+    If your application is based on Symfony 2.x version, replace ``php bin/console``
+    with ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage
@@ -18,14 +18,14 @@ determine the bundle and the command name:
 
 .. code-block:: bash
 
-    $ php app/console generate:command
+    $ php bin/console generate:command
 
 The command can be run in a non interactive mode by using the
 ``--no-interaction`` and providing the needed arguments:
 
 .. code-block:: bash
 
-    $ php app/console generate:command --no-interaction AcmeBlogBundle blog:publish-posts
+    $ php bin/console generate:command --no-interaction AcmeBlogBundle blog:publish-posts
 
 Available Arguments
 -------------------

--- a/Resources/doc/commands/generate_controller.rst
+++ b/Resources/doc/commands/generate_controller.rst
@@ -3,8 +3,8 @@ Generating a New Controller
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php app/console`` by
-    ``php bin/console`` before executing any of the console commands included
+    If your application is based on Symfony 2.x version, replace ``php bin/console``
+    with ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage
@@ -19,14 +19,14 @@ structure:
 
 .. code-block:: bash
 
-    $ php app/console generate:controller
+    $ php bin/console generate:controller
 
 The command can be run in a non-interactive mode by using the ``--no-interaction``
 option without forgetting all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:controller --no-interaction --controller=AcmeBlogBundle:Post
+    $ php bin/console generate:controller --no-interaction --controller=AcmeBlogBundle:Post
 
 Available Options
 -----------------
@@ -39,7 +39,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:controller --controller=AcmeBlogBundle:Post
+        $ php bin/console generate:controller --controller=AcmeBlogBundle:Post
 
 ``--actions``
     The list of actions to generate in the controller class. This has a format
@@ -47,10 +47,10 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:controller --actions="showPostAction:/article/{id} getListAction:/_list-posts/{max}:AcmeBlogBundle:Post:list_posts.html.twig"
+        $ php bin/console generate:controller --actions="showPostAction:/article/{id} getListAction:/_list-posts/{max}:AcmeBlogBundle:Post:list_posts.html.twig"
 
         # or
-        $ php app/console generate:controller --actions=showPostAction:/article/{id} --actions=getListAction:/_list-posts/{max}:AcmeBlogBundle:Post:list_posts.html.twig
+        $ php bin/console generate:controller --actions=showPostAction:/article/{id} --actions=getListAction:/_list-posts/{max}:AcmeBlogBundle:Post:list_posts.html.twig
 
 ``--route-format``
     **allowed values**: ``annotation|php|yml|xml`` **default**: ``annotation``
@@ -60,7 +60,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:controller --route-format=annotation
+        $ php bin/console generate:controller --route-format=annotation
 
 ``--template-format``
     **allowed values**: ``php|twig`` **default**: ``twig``
@@ -70,4 +70,4 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:controller --template-format=twig
+        $ php bin/console generate:controller --template-format=twig

--- a/Resources/doc/commands/generate_doctrine_crud.rst
+++ b/Resources/doc/commands/generate_doctrine_crud.rst
@@ -3,8 +3,8 @@ Generating a CRUD Controller Based on a Doctrine Entity
 
 .. caution::
 
-    If your application is based on Symfony 3, replace ``php app/console`` by
-    ``php bin/console`` before executing any of the console commands included
+    If your application is based on Symfony 2.x version, replace ``php bin/console``
+    with ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage
@@ -26,14 +26,14 @@ actions:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:crud
+    $ php bin/console generate:doctrine:crud
 
 To deactivate the interactive mode, use the ``--no-interaction`` option, but don't
 forget to pass all needed options:
 
 .. code-block:: bash
 
-    $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post --format=annotation --with-write --no-interaction
+    $ php bin/console generate:doctrine:crud --entity=AcmeBlogBundle:Post --format=annotation --with-write --no-interaction
 
 Available Options
 -----------------
@@ -45,14 +45,14 @@ Available Options
 
     .. code-block:: bash
 
-      $ php app/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
+      $ php bin/console generate:doctrine:crud --entity=AcmeBlogBundle:Post
 
 ``--route-prefix``
     The prefix to use for each route that identifies an action:
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --route-prefix=acme_post
+        $ php bin/console generate:doctrine:crud --route-prefix=acme_post
 
 ``--with-write``
     **allowed values**: ``yes|no`` **default**: ``no``
@@ -62,7 +62,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --with-write
+        $ php bin/console generate:doctrine:crud --with-write
 
 ``--format``
     **allowed values**: ``annotation|php|yml|xml`` **default**: ``annotation``
@@ -74,7 +74,7 @@ Available Options
 
     .. code-block:: bash
 
-        $ php app/console generate:doctrine:crud --format=annotation
+        $ php bin/console generate:doctrine:crud --format=annotation
 
 ``--overwrite``
     **allowed values**: ``yes|no`` **default**: ``no``
@@ -83,6 +83,6 @@ Available Options
 
     .. code-block:: bash
 
-         $ php app/console generate:doctrine:crud --overwrite
+         $ php bin/console generate:doctrine:crud --overwrite
 
 .. _`SensioFrameworkExtraBundle`: http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/index.html

--- a/Resources/doc/commands/generate_doctrine_entity.rst
+++ b/Resources/doc/commands/generate_doctrine_entity.rst
@@ -3,8 +3,8 @@ Generating a New Doctrine Entity Stub
 
 .. caution::
 
-    If your application is based on Symfony 2, replace ``php bin/console`` by
-    ``php app/console`` before executing any of the console commands included
+    If your application is based on Symfony 2.x version, replace ``php bin/console``
+    with ``php app/console`` before executing any of the console commands included
     in this article.
 
 Usage


### PR DESCRIPTION
Update the files missed by #552 and, before it, #491, using the rewording of commit 5696bff02626571bb562454291c5f71becf388d6 (therefore, of the 6 files of #460, `generate_doctrine_form.rst` is unchanged).