### PR TITLE
Updated displaying of the "Summary before generation" in some commands

### DIFF
--- a/Command/GenerateCommandCommand.php
+++ b/Command/GenerateCommandCommand.php
@@ -128,10 +128,8 @@ EOT
         }
 
         // summary and confirmation
+        $questionHelper->writeSection($output, 'Summary before generation');
         $output->writeln(array(
-            '',
-            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg-white', true),
-            '',
             sprintf('You are going to generate a <info>%s</info> command inside <info>%s</info> bundle.', $name, $bundle),
         ));
 

--- a/Command/GenerateControllerCommand.php
+++ b/Command/GenerateControllerCommand.php
@@ -195,10 +195,8 @@ EOT
         $input->setOption('actions', $this->addActions($input, $output, $questionHelper));
 
         // summary
+        $questionHelper->writeSection($output, 'Summary before generation');
         $output->writeln(array(
-            '',
-            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg-white', true),
-            '',
             sprintf('You are going to generate a "<info>%s:%s</info>" controller', $bundle, $controller),
             sprintf('using the "<info>%s</info>" format for the routing and the "<info>%s</info>" format', $routeFormat, $templateFormat),
             'for templating',

--- a/Command/GenerateDoctrineCrudCommand.php
+++ b/Command/GenerateDoctrineCrudCommand.php
@@ -220,10 +220,8 @@ EOT
         $input->setOption('route-prefix', $prefix);
 
         // summary
+        $questionHelper->writeSection($output, 'Summary before generation');
         $output->writeln(array(
-            '',
-            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg=white', true),
-            '',
             sprintf('You are going to generate a CRUD controller for "<info>%s:%s</info>"', $bundle, $entity),
             sprintf('using the "<info>%s</info>" format.', $format),
             '',


### PR DESCRIPTION
I updated displaying of the "Summary before generation" section in the GenerateControllerCommand and GenerateDoctrineCrudCommand. There was a small typo ("bg=blue;fg-white") in the GenerateControllerCommand class. It was the cause of different displaying of the "Summary before generation" section in comparison with other sections like "Welcome to the Symfony controller generator" or "Controller generation". Especially the "Summary before generation" section was unreadable in PhpStorm. 
It looked this way:
![incorrect_section_presentation](https://user-images.githubusercontent.com/4804166/33661590-10c41e06-daa2-11e7-80c5-e618e5fc9f73.png)
There is how it looked in PhpStorm in the bottom of the screenshot and how it looked in the Linux console in the top of the screenshot.
The GenerateDoctrineCrudCommand class did not have the same error but i updated the "Summary before generation" section there to make the section in these classes the same.