### PR TITLE
Add a coma at the end of configured options

### DIFF
--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -34,7 +34,7 @@ class {{ form_class }} extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => '{{ namespace }}\Entity{{ entity_namespace ? '\\' ~ entity_namespace : '' }}\{{ entity_class }}'
+            'data_class' => '{{ namespace }}\Entity{{ entity_namespace ? '\\' ~ entity_namespace : '' }}\{{ entity_class }}',
         ));
     }
 


### PR DESCRIPTION
Too many times have I duplicated the line to add a new default, to find myself with a 

> `Parse error: syntax error, unexpected 'option' (T_CONSTANT_ENCAPSED_STRING), expecting ')'`
 
in my hands.

Hope this helps.