### PR TITLE
@Method annotation removed in Controller's actions in order to have new "methods" argument inside @Route

### DIFF
--- a/Resources/skeleton/bundle/DefaultController.php.twig
+++ b/Resources/skeleton/bundle/DefaultController.php.twig
@@ -5,7 +5,7 @@ namespace {{ namespace }}\Controller;
 {% block use_statements %}
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 {% if 'annotation' == format -%}
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 {% endif %}
 {% endblock use_statements %}
 

--- a/Resources/skeleton/controller/Controller.php.twig
+++ b/Resources/skeleton/controller/Controller.php.twig
@@ -5,7 +5,7 @@ namespace {{ namespace }}\Controller;
 {% block use_statements %}
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 {% if 'annotation' == format.routing -%}
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 {% endif %}
 {% endblock use_statements %}
 

--- a/Resources/skeleton/crud/actions/delete.php.twig
+++ b/Resources/skeleton/crud/actions/delete.php.twig
@@ -6,8 +6,7 @@
      *
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}
-     * @Route("/{{ '{' ~ identifier ~ '}' }}", name="{{ route_name_prefix }}_delete")
-     * @Method("DELETE")
+     * @Route("/{{ '{' ~ identifier ~ '}' }}", name="{{ route_name_prefix }}_delete", methods={"DELETE"})
 {% endif %}
 {% endblock phpdoc_method_annotations %}
      */

--- a/Resources/skeleton/crud/actions/edit.php.twig
+++ b/Resources/skeleton/crud/actions/edit.php.twig
@@ -6,8 +6,7 @@
      *
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}
-     * @Route("/{{ '{' ~ identifier ~ '}' }}/edit", name="{{ route_name_prefix }}_edit")
-     * @Method({"GET", "POST"})
+     * @Route("/{{ '{' ~ identifier ~ '}' }}/edit", name="{{ route_name_prefix }}_edit", methods={"GET", "POST"})
 {% endif %}
 {% endblock phpdoc_method_annotations %}
      */

--- a/Resources/skeleton/crud/actions/index.php.twig
+++ b/Resources/skeleton/crud/actions/index.php.twig
@@ -5,8 +5,7 @@
      *
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}
-     * @Route("/", name="{{ route_name_prefix }}_index")
-     * @Method("GET")
+     * @Route("/", name="{{ route_name_prefix }}_index", methods={"GET"})
 {% endif %}
 {% endblock phpdoc_method_annotations %}
      */

--- a/Resources/skeleton/crud/actions/new.php.twig
+++ b/Resources/skeleton/crud/actions/new.php.twig
@@ -6,8 +6,7 @@
      *
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}
-     * @Route("/new", name="{{ route_name_prefix }}_new")
-     * @Method({"GET", "POST"})
+     * @Route("/new", name="{{ route_name_prefix }}_new", methods={"GET", "POST"})
 {% endif %}
 {% endblock phpdoc_method_annotations %}
      */

--- a/Resources/skeleton/crud/actions/show.php.twig
+++ b/Resources/skeleton/crud/actions/show.php.twig
@@ -6,8 +6,7 @@
      *
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}
-     * @Route("/{{ '{' ~ identifier ~ '}' }}", name="{{ route_name_prefix }}_show")
-     * @Method("GET")
+     * @Route("/{{ '{' ~ identifier ~ '}' }}", name="{{ route_name_prefix }}_show", methods={"GET"})
 {% endif %}
 {% endblock phpdoc_method_annotations %}
      */

--- a/Resources/skeleton/crud/controller.php.twig
+++ b/Resources/skeleton/crud/controller.php.twig
@@ -9,8 +9,7 @@ use {{ namespace }}\Form\{{ entity }}Type;
 {% endif %}
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 {% if 'annotation' == format -%}
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 {%- endif %}
 {% if 'new' in actions or 'edit' in actions or 'delete' in actions %}
 use Symfony\Component\HttpFoundation\Request;

--- a/Tests/Command/GenerateDoctrineEntityCommandTest.php
+++ b/Tests/Command/GenerateDoctrineEntityCommandTest.php
@@ -46,7 +46,7 @@ class GenerateDoctrineEntityCommandTest extends GenerateCommandTest
             array(array(), "Acme2BlogBundle:Blog/Post\nyml\ncreated_by\n\n255\nfalse\nfalse\ndescription\ntext\nfalse\ntrue\nupdated_at\ndatetime\ntrue\nfalse\nrating\ndecimal\n5\n3\nfalse\nfalse\n\n", array('Blog\\Post', 'yml', array(
                 array('fieldName' => 'createdBy', 'type' => 'string', 'length' => 255, 'columnName' => 'created_by'),
                 array('fieldName' => 'description', 'type' => 'text', 'unique' => true, 'columnName' => 'description'),
-                array('fieldName' => 'updatedAt', 'type' => 'datetimetz', 'nullable' => true, 'columnName' => 'updated_at'),
+                array('fieldName' => 'updatedAt', 'type' => 'datetime', 'nullable' => true, 'columnName' => 'updated_at'),
                 array('fieldName' => 'rating', 'type' => 'decimal', 'precision' => 5, 'scale' => 3, 'columnName' => 'rating'),
             ))),
             // Deprecated, to be removed in 4.0

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -162,11 +162,12 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         $content = file_get_contents($this->tmpDir.'/Controller/PostController.php');
         $strings = array(
             'namespace Foo\BarBundle\Controller;',
+            'use Symfony\Component\Routing\Annotation\Route;',
             'public function indexAction',
             'public function showAction',
             '@Route("/post")', // Controller level
-            '@Route("/", name="post_index")',
-            '@Route("/{id}", name="post_show")',
+            '@Route("/", name="post_index", methods={"GET"})',
+            '@Route("/{id}", name="post_show", methods={"GET"})',
         );
         foreach ($strings as $string) {
             $this->assertContains($string, $content);
@@ -202,11 +203,11 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
         $strings = array(
             'namespace Foo\BarBundle\Controller\Blog;',
             '@Route("/blog_post")', // Controller level
-            '@Route("/", name="blog_post_index")',
-            '@Route("/{id}", name="blog_post_show")',
-            '@Route("/new", name="blog_post_new")',
-            '@Route("/{id}/edit", name="blog_post_edit")',
-            '@Route("/{id}", name="blog_post_delete")',
+            '@Route("/", name="blog_post_index", methods={"GET"})',
+            '@Route("/{id}", name="blog_post_show", methods={"GET"})',
+            '@Route("/new", name="blog_post_new", methods={"GET", "POST"})',
+            '@Route("/{id}/edit", name="blog_post_edit", methods={"GET", "POST"})',
+            '@Route("/{id}", name="blog_post_delete", methods={"DELETE"})',
             'public function showAction(Post $post)',
             '\'post\' => $post,',
             '\'posts\' => $posts,',

--- a/Tests/Generator/DoctrineCrudGeneratorTest.php
+++ b/Tests/Generator/DoctrineCrudGeneratorTest.php
@@ -173,6 +173,16 @@ class DoctrineCrudGeneratorTest extends GeneratorTest
             $this->assertContains($string, $content);
         }
 
+        $strings = array(
+            'use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;',
+            'use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;',
+            '@Method'
+        );
+        foreach ($strings as $string) {
+            $this->assertNotContains($string, $content);
+        }
+
+
         $content = file_get_contents($this->tmpDir.'/Controller/PostController.php');
         $strings = array(
             'public function newAction',


### PR DESCRIPTION
Hi.
I found out that the `doctrine:generate:crud` task was using the old `@Method` annotation for generated actions inside Controllers. I updated the `use` inside the controllers skeletons and also the `@Method` annotation was removed in order to use the new argument `methods` inside the annotation `@Route` .

Because of this, functionalities like the delete button for a database record was not working due to the use of the deprecated `@Method` annotation. 

I also fixed a `datetime` assertion that was making one of the tests to fail. And updated the `testGenerateAnnotation` in DoctrineCrudGeneratorTest.php to verify that the new generateds annotations are working find and to verify that the old ones are not used anymore.

In travis the build is failing due to deprecations.
![selection_059](https://user-images.githubusercontent.com/4495677/48444323-ea2fa580-e793-11e8-958d-aaf59d7e8247.png)
